### PR TITLE
[Fix] modify _freeze_stages logic, 0 for embed and 4 for all stages.

### DIFF
--- a/tests/test_models/test_backbones/test_swin_transformer.py
+++ b/tests/test_models/test_backbones/test_swin_transformer.py
@@ -193,16 +193,18 @@ def test_structure():
     assert check_norm_state(model.modules(), False)
 
     # Test Swin-Transformer with first stage frozen.
-    frozen_stages = 0
+    frozen_stages = 1
     model = SwinTransformer(
         arch='small', frozen_stages=frozen_stages, out_indices=(0, 1, 2, 3))
     model.init_weights()
     model.train()
 
+    # Test Swin-Transformer patch_embed.
     assert model.patch_embed.training is False
     for param in model.patch_embed.parameters():
         assert param.requires_grad is False
-    for i in range(frozen_stages + 1):
+
+    for i in range(frozen_stages):
         stage = model.stages[i]
         for param in stage.parameters():
             assert param.requires_grad is False
@@ -215,6 +217,16 @@ def test_structure():
         assert param.requires_grad is True
     for param in model.norm1.parameters():
         assert param.requires_grad is True
+
+    # Test Swin-Transformer with all stages frozen.
+    frozen_stages = 4
+    model = SwinTransformer(
+        arch='small', frozen_stages=frozen_stages, out_indices=(0, 1, 2, 3))
+    model.init_weights()
+    model.train()
+
+    for p in model.parameters():
+        assert not p.requires_grad
 
 
 def test_load_checkpoint():


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

To align _freeze_stages function logic with MMDet and MMSeg

## Modification

swin_ransformer.py: modify _freeze_stages logic, 0 for embed and 4 for all stages.


## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
