### PR TITLE
[Feature] Support ViT Anti Oversmoothing

### DIFF
--- a/mmcls/models/backbones/deit.py
+++ b/mmcls/models/backbones/deit.py
@@ -37,6 +37,15 @@ class DistilledVisionTransformer(VisionTransformer):
         drop_rate (float): Probability of an element to be zeroed.
             Defaults to 0.
         drop_path_rate (float): stochastic depth rate. Defaults to 0.
+        feat_scale (bool): If True, use FeatScale.
+            FeatScale re-weights feature maps on separate frequency bands
+            to amplify the high-frequency signals.
+            Defaults to False.
+        attn_scale (bool): If True, use AttnScale.
+            AttnScale decomposes a self-attention block into low-pass and
+            high-pass components, then rescales and combines these two filters
+            to produce an all-pass self-attention matrix.
+            Defaults to False.
         qkv_bias (bool): Whether to add bias for qkv in attention modules.
             Defaults to True.
         norm_cfg (dict): Config dict for normalization layer.

--- a/mmcls/models/backbones/swin_transformer.py
+++ b/mmcls/models/backbones/swin_transformer.py
@@ -34,6 +34,15 @@ class SwinBlock(BaseModule):
             avoid shifting window and shrink the window size to the size of
             feature map, which is common used in classification.
             Defaults to False.
+        feat_scale (bool): If True, use FeatScale.
+            FeatScale re-weights feature maps on separate frequency bands
+            to amplify the high-frequency signals.
+            Defaults to False.
+        attn_scale (bool): If True, use AttnScale.
+            AttnScale decomposes a self-attention block into low-pass and
+            high-pass components, then rescales and combines these two filters
+            to produce an all-pass self-attention matrix.
+            Defaults to False.
         attn_cfgs (dict): The extra config of Shift Window-MSA.
             Defaults to empty dict.
         ffn_cfgs (dict): The extra config of FFN. Defaults to empty dict.
@@ -53,6 +62,8 @@ class SwinBlock(BaseModule):
                  ffn_ratio=4.,
                  drop_path=0.,
                  pad_small_map=False,
+                 feat_scale=False,
+                 attn_scale=False,
                  attn_cfgs=dict(),
                  ffn_cfgs=dict(),
                  norm_cfg=dict(type='LN'),
@@ -69,6 +80,7 @@ class SwinBlock(BaseModule):
             'window_size': window_size,
             'dropout_layer': dict(type='DropPath', drop_prob=drop_path),
             'pad_small_map': pad_small_map,
+            'attn_scale': attn_scale,
             **attn_cfgs
         }
         self.norm1 = build_norm_layer(norm_cfg, embed_dims)[1]
@@ -86,12 +98,29 @@ class SwinBlock(BaseModule):
         self.norm2 = build_norm_layer(norm_cfg, embed_dims)[1]
         self.ffn = FFN(**_ffn_cfgs)
 
+        self.feat_scale = feat_scale
+        if self.feat_scale:
+            self.lamb1 = nn.Parameter(
+                torch.zeros(embed_dims), requires_grad=True)
+            self.lamb2 = nn.Parameter(
+                torch.zeros(embed_dims), requires_grad=True)
+
+    def freq_decompose(self, x):
+        x_d = torch.mean(x, -2, keepdim=True)  # [bs, 1, dim]
+        x_h = x - x_d  # high freq [bs, len, dim]
+        return x_d, x_h
+
     def forward(self, x, hw_shape):
 
         def _inner_forward(x):
             identity = x
             x = self.norm1(x)
             x = self.attn(x, hw_shape)
+            if self.feat_scale:
+                x_d, x_h = self.freq_decompose(x)
+                x_d = x_d * self.lamb1
+                x_h = x_h * self.lamb2
+                x = x + x_d + x_h
             x = x + identity
 
             identity = x
@@ -131,6 +160,15 @@ class SwinBlockSequence(BaseModule):
             avoid shifting window and shrink the window size to the size of
             feature map, which is common used in classification.
             Defaults to False.
+        feat_scale (bool): If True, use FeatScale.
+            FeatScale re-weights feature maps on separate frequency bands
+            to amplify the high-frequency signals.
+            Defaults to False.
+        attn_scale (bool): If True, use AttnScale.
+            AttnScale decomposes a self-attention block into low-pass and
+            high-pass components, then rescales and combines these two filters
+            to produce an all-pass self-attention matrix.
+            Defaults to False.
         init_cfg (dict, optional): The extra config for initialization.
             Defaults to None.
     """
@@ -146,6 +184,8 @@ class SwinBlockSequence(BaseModule):
                  block_cfgs=dict(),
                  with_cp=False,
                  pad_small_map=False,
+                 feat_scale=False,
+                 attn_scale=False,
                  init_cfg=None):
         super().__init__(init_cfg)
 
@@ -166,6 +206,8 @@ class SwinBlockSequence(BaseModule):
                 'drop_path': drop_paths[i],
                 'with_cp': with_cp,
                 'pad_small_map': pad_small_map,
+                'feat_scale': feat_scale,
+                'attn_scale': attn_scale,
                 **block_cfgs[i]
             }
             block = SwinBlock(**_block_cfg)
@@ -247,6 +289,15 @@ class SwinTransformer(BaseBackbone):
             avoid shifting window and shrink the window size to the size of
             feature map, which is common used in classification.
             Defaults to False.
+        feat_scale (bool): If True, use FeatScale.
+            FeatScale re-weights feature maps on separate frequency bands
+            to amplify the high-frequency signals.
+            Defaults to False.
+        attn_scale (bool): If True, use AttnScale.
+            AttnScale decomposes a self-attention block into low-pass and
+            high-pass components, then rescales and combines these two filters
+            to produce an all-pass self-attention matrix.
+            Defaults to False.
         norm_cfg (dict): Config dict for normalization layer for all output
             features. Defaults to ``dict(type='LN')``
         stage_cfgs (Sequence[dict] | dict): Extra config dict for each
@@ -306,6 +357,8 @@ class SwinTransformer(BaseBackbone):
                  frozen_stages=-1,
                  norm_eval=False,
                  pad_small_map=False,
+                 feat_scale=False,
+                 attn_scale=False,
                  norm_cfg=dict(type='LN'),
                  stage_cfgs=dict(),
                  patch_cfg=dict(),
@@ -379,6 +432,8 @@ class SwinTransformer(BaseBackbone):
                 'drop_paths': dpr[:depth],
                 'with_cp': with_cp,
                 'pad_small_map': pad_small_map,
+                'feat_scale': feat_scale,
+                'attn_scale': attn_scale,
                 **stage_cfg
             }
 

--- a/tests/test_models/test_backbones/test_swin_transformer.py
+++ b/tests/test_models/test_backbones/test_swin_transformer.py
@@ -160,6 +160,26 @@ class TestSwinTransformer(TestCase):
         feat = outs[-1]
         self.assertEqual(feat.shape, (3, 1024, 7, 7))
 
+        # test with attn_scale=True
+        cfg = deepcopy(self.cfg)
+        cfg['attn_scale'] = True
+        model = SwinTransformer(**cfg)
+        outs = model(torch.randn(3, 3, 224, 224))
+        self.assertIsInstance(outs, tuple)
+        self.assertEqual(len(outs), 1)
+        feat = outs[-1]
+        self.assertEqual(feat.shape, (3, 1024, 7, 7))
+
+        # test with feat_scale=True
+        cfg = deepcopy(self.cfg)
+        cfg['feat_scale'] = True
+        model = SwinTransformer(**cfg)
+        outs = model(torch.randn(3, 3, 224, 224))
+        self.assertIsInstance(outs, tuple)
+        self.assertEqual(len(outs), 1)
+        feat = outs[-1]
+        self.assertEqual(feat.shape, (3, 1024, 7, 7))
+
         # test multiple output indices
         cfg = deepcopy(self.cfg)
         cfg['out_indices'] = (0, 1, 2, 3)

--- a/tests/test_models/test_backbones/test_vision_transformer.py
+++ b/tests/test_models/test_backbones/test_vision_transformer.py
@@ -166,6 +166,28 @@ class TestVisionTransformer(TestCase):
             self.assertEqual(patch_token.shape, (3, 768, 14, 14))
             self.assertEqual(cls_token.shape, (3, 768))
 
+        # test with attn_scale=True
+        cfg = deepcopy(self.cfg)
+        cfg['attn_scale'] = True
+        model = VisionTransformer(**cfg)
+        outs = model(imgs)
+        self.assertIsInstance(outs, tuple)
+        self.assertEqual(len(outs), 1)
+        patch_token, cls_token = outs[-1]
+        self.assertEqual(patch_token.shape, (3, 768, 14, 14))
+        self.assertEqual(cls_token.shape, (3, 768))
+
+        # test with feat_scale=True
+        cfg = deepcopy(self.cfg)
+        cfg['feat_scale'] = True
+        model = VisionTransformer(**cfg)
+        outs = model(imgs)
+        self.assertIsInstance(outs, tuple)
+        self.assertEqual(len(outs), 1)
+        patch_token, cls_token = outs[-1]
+        self.assertEqual(patch_token.shape, (3, 768, 14, 14))
+        self.assertEqual(cls_token.shape, (3, 768))
+
         # Test forward with dynamic input size
         imgs1 = torch.randn(3, 3, 224, 224)
         imgs2 = torch.randn(3, 3, 256, 256)


### PR DESCRIPTION
## Motivation

Support ViT Anti Oversmoothing.

[Anti-Oversmoothing in Deep Vision Transformers via the Fourier Domain Analysis: From Theory to Practice](https://arxiv.org/pdf/2203.05962v1.pdf)
[official repo](https://github.com/VITA-Group/ViT-Anti-Oversmoothing)

Since imagenet training is difficult at hand, I have not been able to verify the accuracy.
Also, I only support Swin and ViT, but can support other transformer models.  Let me know if you need.

## Result
CUB200
bs8×1GPU

|  model  |  top1 acc  |
| ---- | ---- |
|  swin-l  |  91.6638 |
|  + feat scale  |  91.81913 |
|  + attn scale  |  91.56024 |
|  + feat and attn scale  |  91.78461 |

Since I have not done imagenet pretraining, the accuracy is probably only for reference.
If we start with imagenet training, the accuracy may be further improved, but the effect may be limited (accuracy + 0.XX).

## Use cases (Optional)

```
# model settings
model = dict(
    type='ImageClassifier',
    backbone=dict(
        type='SwinTransformer', arch='small', img_size=224,
        drop_path_rate=0.3, attn_scale=True),
    neck=dict(type='GlobalAveragePooling'),
    head=dict(
        type='LinearClsHead',
        num_classes=1000,
        in_channels=768,
        init_cfg=None,  # suppress the default init_cfg of LinearClsHead.
        loss=dict(
            type='LabelSmoothLoss', label_smooth_val=0.1, mode='original'),
        cal_acc=False),
    init_cfg=[
        dict(type='TruncNormal', layer='Linear', std=0.02, bias=0.),
        dict(type='Constant', layer='LayerNorm', val=1., bias=0.)
    ],
    train_cfg=dict(augments=[
        dict(type='BatchMixup', alpha=0.8, num_classes=1000, prob=0.5),
        dict(type='BatchCutMix', alpha=1.0, num_classes=1000, prob=0.5)
    ]))
```

```
# model settings
model = dict(
    type='ImageClassifier',
    backbone=dict(
        type='SwinTransformer', arch='small', img_size=224,
        drop_path_rate=0.3, feat_scale=True),
    neck=dict(type='GlobalAveragePooling'),
    head=dict(
        type='LinearClsHead',
        num_classes=1000,
        in_channels=768,
        init_cfg=None,  # suppress the default init_cfg of LinearClsHead.
        loss=dict(
            type='LabelSmoothLoss', label_smooth_val=0.1, mode='original'),
        cal_acc=False),
    init_cfg=[
        dict(type='TruncNormal', layer='Linear', std=0.02, bias=0.),
        dict(type='Constant', layer='LayerNorm', val=1., bias=0.)
    ],
    train_cfg=dict(augments=[
        dict(type='BatchMixup', alpha=0.8, num_classes=1000, prob=0.5),
        dict(type='BatchCutMix', alpha=1.0, num_classes=1000, prob=0.5)
    ]))
```

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.
- [x] Check accuracy with CUB.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
