### PR TITLE
Different samples for eval train test

### DIFF
--- a/mmcls/apis/train.py
+++ b/mmcls/apis/train.py
@@ -82,11 +82,15 @@ def train_model(model,
 
     sampler_cfg = cfg.data.get('sampler', None)
 
+    samples_per_gpu = cfg.data.train.pop(
+        'samples_per_gpu', cfg.data.samples_per_gpu)
+    workers_per_gpu = cfg.data.train.pop(
+        'workers_per_gpu', cfg.data.workers_per_gpu)
     data_loaders = [
         build_dataloader(
             ds,
-            cfg.data.samples_per_gpu,
-            cfg.data.workers_per_gpu,
+            samples_per_gpu,
+            workers_per_gpu,
             # cfg.gpus will be ignored if distributed
             num_gpus=len(cfg.gpu_ids),
             dist=distributed,
@@ -168,11 +172,15 @@ def train_model(model,
 
     # register eval hooks
     if validate:
+        samples_per_gpu = cfg.data.val.pop(
+            'samples_per_gpu', cfg.data.samples_per_gpu)
+        workers_per_gpu = cfg.data.val.pop(
+            'workers_per_gpu', cfg.data.workers_per_gpu)
         val_dataset = build_dataset(cfg.data.val, dict(test_mode=True))
         val_dataloader = build_dataloader(
             val_dataset,
-            samples_per_gpu=cfg.data.samples_per_gpu,
-            workers_per_gpu=cfg.data.workers_per_gpu,
+            samples_per_gpu=samples_per_gpu,
+            workers_per_gpu=workers_per_gpu,
             dist=distributed,
             shuffle=False,
             round_up=True)

--- a/tools/test.py
+++ b/tools/test.py
@@ -136,12 +136,16 @@ def main():
         init_dist(args.launcher, **cfg.dist_params)
 
     # build the dataloader
+    samples_per_gpu = cfg.data.test.pop(
+        'samples_per_gpu', cfg.data.samples_per_gpu)
+    workers_per_gpu = cfg.data.test.pop(
+        'workers_per_gpu', cfg.data.workers_per_gpu)
     dataset = build_dataset(cfg.data.test, default_args=dict(test_mode=True))
     # the extra round_up data will be removed during gpu/cpu collect
     data_loader = build_dataloader(
         dataset,
-        samples_per_gpu=cfg.data.samples_per_gpu,
-        workers_per_gpu=cfg.data.workers_per_gpu,
+        samples_per_gpu=samples_per_gpu,
+        workers_per_gpu=workers_per_gpu,
         dist=distributed,
         shuffle=False,
         round_up=True)


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

some device cannot use same samples for train/eval/test modes, so set samples_per_gpu and workers_per_gpu individually.

## Modification

add cfg.data.train.samples_per_gpu, cfg.data.train.workers_per_gpu, cfg.data.val.samples_per_gpu, cfg.data.val.workers_per_gpu, cfg.data.test.samples_per_gpu, cfg.data.test.workers_per_gpu

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
