### PR TITLE
configure stem_stride in repvgg to train with CIFAR

### DIFF
--- a/mmcls/models/backbones/repvgg.py
+++ b/mmcls/models/backbones/repvgg.py
@@ -390,6 +390,7 @@ class RepVGG(BaseBackbone):
                  arch,
                  in_channels=3,
                  base_channels=64,
+                 stem_stride=2,
                  out_indices=(3, ),
                  strides=(2, 2, 2, 2),
                  dilations=(1, 1, 1, 1),
@@ -445,7 +446,7 @@ class RepVGG(BaseBackbone):
         self.stem = RepVGGBlock(
             self.in_channels,
             channels,
-            stride=2,
+            stride=stem_stride,
             se_cfg=arch['se_cfg'],
             with_cp=with_cp,
             conv_cfg=conv_cfg,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

For training cifar10/cifar100, the performance would be better if the stem stride is set to 1. This is very common in most of the backbones. Here are the [examples](https://github.com/kuangliu/pytorch-cifar)

## Modification

make stem stride configurable

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
