### PR TITLE
[Enhance] Add `get_layer_depth` method.

### DIFF
--- a/mmcls/models/backbones/convnext.py
+++ b/mmcls/models/backbones/convnext.py
@@ -331,3 +331,47 @@ class ConvNeXt(BaseBackbone):
     def train(self, mode=True):
         super(ConvNeXt, self).train(mode)
         self._freeze_stages()
+
+    def get_layer_depth(self, parameter_name: str, prefix: str = ''):
+        """Get the stage-wise depth and block-wise depth of a parameter.
+
+        Args:
+            parameter_name (str): The name of the parameter.
+            prefix (str): The prefix for the parameter.
+                Defaults to an empty string.
+
+        Returns:
+            Tuple[int, int]: The stage-wise depth and the block-wise depth.
+        """
+        import re
+
+        import numpy as np
+
+        cumsum_depths = [0] + np.cumsum(self.depths).tolist()
+
+        # Downsample layers
+        match_pattern = prefix + r'downsample_layers\.(\d+)'
+        match_result = re.match(match_pattern, parameter_name)
+        if match_result is not None:
+            stage_id = int(match_result.groups()[0])
+            block_id = cumsum_depths[stage_id]
+            return stage_id + 1, block_id
+
+        # Stage layers
+        match_pattern = prefix + r'stages\.(\d+)\.(\d+)'
+        match_result = re.match(match_pattern, parameter_name)
+        if match_result is not None:
+            stage_id = int(match_result.groups()[0])
+            inner_block_id = int(match_result.groups()[1])
+            block_id = cumsum_depths[stage_id] + inner_block_id
+            return stage_id + 1, block_id + 1
+
+        # Out norm layers
+        match_pattern = prefix + r'norm(\d+)'
+        match_result = re.match(match_pattern, parameter_name)
+        if match_result is not None:
+            stage_id = int(match_result.groups()[0])
+            block_id = cumsum_depths[stage_id + 1]
+            return stage_id + 1, block_id
+
+        raise ValueError(f'Invalid parameter name "{parameter_name}".')

--- a/tests/test_models/test_backbones/test_convnext.py
+++ b/tests/test_models/test_backbones/test_convnext.py
@@ -84,3 +84,33 @@ def test_convnext():
     for i in range(2, 4):
         assert model.downsample_layers[i].training
         assert model.stages[i].training
+
+    # Test get_layer_depth
+    model = ConvNeXt(arch='tiny', out_indices=(0, 1, 2, 3))
+
+    # test invalid parameter
+    with pytest.raises(ValueError):
+        model.get_layer_depth('backbone.unknown')
+
+    # test blocks
+    key = 'backbone.stages.3.1.pointwise_conv1.weight'
+    stage_id, block_id = model.get_layer_depth(key, prefix='backbone.')
+    assert stage_id == 4
+    assert block_id == 3 + 3 + 9 + 2
+
+    # test downsample layers
+    key = 'backbone.downsample_layers.2.1.weight'
+    stage_id, block_id = model.get_layer_depth(key, prefix='backbone.')
+    assert stage_id == 3
+    assert block_id == 3 + 3
+
+    # test out norm layers
+    key = 'backbone.norm3.weight'
+    stage_id, block_id = model.get_layer_depth(key, prefix='backbone.')
+    assert stage_id == 4
+    assert block_id == 3 + 3 + 9 + 3
+
+    key = 'backbone.norm2.bias'
+    stage_id, block_id = model.get_layer_depth(key, prefix='backbone.')
+    assert stage_id == 3
+    assert block_id == 3 + 3 + 9


### PR DESCRIPTION
## Motivation

Some optimizer constructors set different learning rate for layers of different depth.

## Modification

Add `get_layer_depth` method for `VisionTransformer`, `ConvNeXt` and `SwinTransformer`.

## Use cases (Optional)

**Vision Transformer**
```python
>>> from mmcls.models import VisionTransformer
>>> 
>>> backbone = VisionTransformer(arch='base')
>>> # Parameter of the patch embedding layer
>>> backbone.get_layer_depth('patch_embed.projection.bias')
(0, 0)
>>> # Parameter of the 6th layer
>>> # Since ViT doesn't have stage-level, all stage-wise depths are 0.
>>> backbone.get_layer_depth('layers.5.attn.proj.weight')
(0, 6)
```

**ConvNeXt**
```python
>>> from mmcls.models import ConvNeXt
>>> 
>>> backbone = ConvNeXt(arch='base')
>>> # Parameter of the 5th block (the 2nd block in the 2nd stage)
>>> # You can use `prefix` to specify the prefix of the parameter name.
>>> backbone.get_layer_depth('backbone.stages.1.1.pointwise_conv1.weight', prefix='backbone.')
(2, 5)
>>> # Parameter of the 2nd downsample layer
>>> # It belongs to the 2nd stage and there are 3 blocks before it.
>>> backbone.get_layer_depth('backbone.downsample_layers.1.1.weight', prefix='backbone.')
(2, 3)
```

**Swin-Transformer**
```python
>>> from mmcls.models import SwinTransformer
>>> 
>>> backbone = SwinTransformer(arch='base')
>>> # Parameter of the 5th block (the 1st block in the 3rd stage)
>>> # You can use `prefix` to specify the prefix of the parameter name.
>>> backbone.get_layer_depth('backbone.stages.2.blocks.0.norm1.weight', prefix='backbone.')
(3, 5)
>>> # Parameter of the 2nd downsample layer
>>> # It belongs to the 2nd stage and there are 4 blocks before it.
>>> backbone.get_layer_depth('backbone.stages.1.downsample.norm.weight', prefix='backbone.')
(2, 4)
```

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
