### PR TITLE
Add ImgAug library. 

### DIFF
--- a/mmcls/datasets/pipelines/transforms.py
+++ b/mmcls/datasets/pipelines/transforms.py
@@ -1139,3 +1139,163 @@ class Albu(object):
     def __repr__(self):
         repr_str = self.__class__.__name__ + f'(transforms={self.transforms})'
         return repr_str
+
+@PIPELINES.register_module()
+class Imgaug:
+    """Imgaug augmentation.
+    
+    Adds custom transformations from imgaug library.
+    Please visit `https://imgaug.readthedocs.io/en/latest/index.html`
+    to get more information.
+
+    It's better to use uint8 images as inputs since imgaug works best with
+    numpy dtype uint8 and isn't well tested with other dtypes. It should be
+    noted that not all of the augmenters have the same input and output dtype,
+    which may cause unexpected results.
+
+    Two steps to use `Imgaug` pipeline:
+    1. Create initialization parameter `transforms`. There are three ways
+        to create `transforms`.
+        1) string: only support `default` for now.
+            e.g. `transforms='default'`
+        2) list[dict]: create a list of augmenters by a list of dicts, each
+            dict corresponds to one augmenter. Every dict MUST contain a key
+            named `type`. `type` should be a string(iaa.Augmenter's name) or
+            an iaa.Augmenter subclass.
+            e.g. `transforms=[dict(type='Rotate', rotate=(-20, 20))]`
+            e.g. `transforms=[dict(type=iaa.Rotate, rotate=(-20, 20))]`
+        3) iaa.Augmenter: create an imgaug.Augmenter object.
+            e.g. `transforms=iaa.Rotate(rotate=(-20, 20))`
+
+    2. Add `Imgaug` in dataset pipeline. It is recommended to insert imgaug
+        pipeline before `Normalize`. An example is as follows:
+
+        .. code-block::
+        dict(type='Imgaug',
+            transforms=[
+                dict(
+                    type='SomeOf',
+                    n=2,
+                    children=[
+                        dict(type='Clouds'),
+                        dict(type='Fog'),
+                        dict(type='Snowflakes'),
+                        dict(type='Rain')])
+            ]),
+
+    Args:
+        transforms (str | list[dict] | :obj:`iaa.Augmenter`): Three different
+            ways to create imgaug augmenter.
+    """
+
+    def __init__(self, transforms):
+        import imgaug.augmenters as iaa
+
+        if transforms == 'default':
+            self.transforms = self.default_transforms()
+        elif isinstance(transforms, list):
+            assert all(isinstance(trans, dict) for trans in transforms)
+            self.transforms = transforms
+        elif isinstance(transforms, iaa.Augmenter):
+            self.aug = self.transforms = transforms
+        else:
+            raise ValueError('transforms must be `default` or a list of dicts'
+                             ' or iaa.Augmenter object')
+
+        if not isinstance(transforms, iaa.Augmenter):
+            self.aug = iaa.Sequential(
+                [self.imgaug_builder(t) for t in self.transforms])
+
+    @staticmethod
+    def default_transforms():
+        """Default transforms for imgaug.
+        Implement RandAugment by imgaug.
+        Please visit `https://arxiv.org/abs/1909.13719` for more information.
+        Augmenters and hyper parameters are borrowed from the following repo:
+        https://github.com/tensorflow/tpu/blob/master/models/official/efficientnet/autoaugment.py # noqa
+        Miss one augmenter ``SolarizeAdd`` since imgaug doesn't support this.
+        Returns:
+            dict: The constructed RandAugment transforms.
+        """
+        # RandAugment hyper params
+        num_augmenters = 2
+        cur_magnitude, max_magnitude = 9, 10
+        cur_level = 1.0 * cur_magnitude / max_magnitude
+
+        return [
+            dict(
+                type='SomeOf',
+                n=num_augmenters,
+                children=[
+                    dict(
+                        type='ShearX',
+                        shear=17.19 * cur_level * random.choice([-1, 1])),
+                    dict(
+                        type='ShearY',
+                        shear=17.19 * cur_level * random.choice([-1, 1])),
+                    dict(
+                        type='TranslateX',
+                        percent=.2 * cur_level * random.choice([-1, 1])),
+                    dict(
+                        type='TranslateY',
+                        percent=.2 * cur_level * random.choice([-1, 1])),
+                    dict(
+                        type='Rotate',
+                        rotate=30 * cur_level * random.choice([-1, 1])),
+                    dict(type='Posterize', nb_bits=max(1, int(4 * cur_level))),
+                    dict(type='Solarize', threshold=256 * cur_level),
+                    dict(type='EnhanceColor', factor=1.8 * cur_level + .1),
+                    dict(type='EnhanceContrast', factor=1.8 * cur_level + .1),
+                    dict(
+                        type='EnhanceBrightness', factor=1.8 * cur_level + .1),
+                    dict(type='EnhanceSharpness', factor=1.8 * cur_level + .1),
+                    dict(type='Autocontrast', cutoff=0),
+                    dict(type='Equalize'),
+                    dict(type='Invert', p=1.),
+                    dict(
+                        type='Cutout',
+                        nb_iterations=1,
+                        size=0.2 * cur_level,
+                        squared=True)
+                ])
+        ]
+
+    def imgaug_builder(self, cfg):
+        """Import a module from imgaug.
+        It follows the logic of :func:`build_from_cfg`. Use a dict object to
+        create an iaa.Augmenter object.
+        Args:
+            cfg (dict): Config dict. It should at least contain the key "type".
+        Returns:
+            obj:`iaa.Augmenter`: The constructed imgaug augmenter.
+        """
+        import imgaug.augmenters as iaa
+
+        assert isinstance(cfg, dict) and 'type' in cfg
+        args = cfg.copy()
+
+        obj_type = args.pop('type')
+        if mmcv.is_str(obj_type):
+            obj_cls = getattr(iaa, obj_type) if hasattr(iaa, obj_type) \
+                else getattr(iaa.pillike, obj_type)
+        elif issubclass(obj_type, iaa.Augmenter):
+            obj_cls = obj_type
+        else:
+            raise TypeError(
+                f'type must be a str or valid type, but got {type(obj_type)}')
+
+        if 'children' in args:
+            args['children'] = [
+                self.imgaug_builder(child) for child in args['children']
+            ]
+        return obj_cls(**args)
+
+    def __repr__(self):
+        repr_str = self.__class__.__name__ + f'(transforms={self.aug})'
+        return repr_str
+
+    def __call__(self, results):
+        assert results['modality'] == 'RGB', 'Imgaug only support RGB images.
+        cur_aug = self.aug.to_deterministic()
+        results['img'] = cur_aug.augment_image(results['img'])
+        return results

--- a/mmcls/datasets/pipelines/transforms.py
+++ b/mmcls/datasets/pipelines/transforms.py
@@ -1295,7 +1295,8 @@ class Imgaug:
         return repr_str
 
     def __call__(self, results):
-        assert results['modality'] == 'RGB', 'Imgaug only support RGB images.
+        # Imgaug only support RGB images
+        assert results['modality'] == 'RGB'
         cur_aug = self.aug.to_deterministic()
         results['img'] = cur_aug.augment_image(results['img'])
         return results

--- a/mmcls/datasets/pipelines/transforms.py
+++ b/mmcls/datasets/pipelines/transforms.py
@@ -1140,10 +1140,11 @@ class Albu(object):
         repr_str = self.__class__.__name__ + f'(transforms={self.transforms})'
         return repr_str
 
+
 @PIPELINES.register_module()
 class Imgaug:
     """Imgaug augmentation.
-    
+
     Adds custom transformations from imgaug library.
     Please visit `https://imgaug.readthedocs.io/en/latest/index.html`
     to get more information.
@@ -1209,6 +1210,7 @@ class Imgaug:
     @staticmethod
     def default_transforms():
         """Default transforms for imgaug.
+
         Implement RandAugment by imgaug.
         Please visit `https://arxiv.org/abs/1909.13719` for more information.
         Augmenters and hyper parameters are borrowed from the following repo:
@@ -1262,6 +1264,7 @@ class Imgaug:
 
     def imgaug_builder(self, cfg):
         """Import a module from imgaug.
+
         It follows the logic of :func:`build_from_cfg`. Use a dict object to
         create an iaa.Augmenter object.
         Args:


### PR DESCRIPTION
## Motivation
Supports [ImgAug library](https://github.com/aleju/imgaug) to enrich MMClassification augmentation methods.

## Modification
A new class, `Imgaug`, is added in `mmcls/datasets/pipelines/transforms.py`. Similar to the function of 'Albu' class, `Imgaug` could empower developers to directly utilize the `ImgAug` library when working with MMClassification. 

In fact, these codes are revised from MMAction2. Specifically, I changed the input from videos to images, and removed lines of dealing with bboxes.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
