### PR TITLE
docs(build): use python -m pip instead of pip

### DIFF
--- a/docs/en/community/CONTRIBUTING.md
+++ b/docs/en/community/CONTRIBUTING.md
@@ -37,7 +37,7 @@ The config for a pre-commit hook is stored in [.pre-commit-config](https://githu
 After you clone the repository, you will need to install initialize pre-commit hook.
 
 ```shell
-pip install -U pre-commit
+python3 -m pip install -U pre-commit
 ```
 
 From the repository folder

--- a/docs/en/install.md
+++ b/docs/en/install.md
@@ -87,7 +87,7 @@ the `dev` branch, please try to update `mmcv` to the latest version.
    A better choice is to use [MIM](https://github.com/open-mmlab/mim) to automatically select the mmcv-full version. MIM will automatically install mmcv-full when you use it to install MMClassification in the next section.
 
    ```shell
-   pip install openmim
+   python3 -m pip install openmim
    ```
 
 ## Install MMClassification repository
@@ -104,7 +104,7 @@ MMClassification. MIM will automatically install the mmcv-full which fits your
 environment. In addition, MIM also has some other functions to help to do
 training, parameter searching and model filtering, etc.
 
-Or, you can use pip to install MMClassification with `pip install mmcls`. In
+Or, you can use pip to install MMClassification with `python3 -m pip install mmcls`. In
 this situation, if you want to use mmcv-full, please install it manually in
 advance.
 
@@ -139,7 +139,7 @@ version number).
    Or use pip, and if you want to use mmcv-full, you need to install it manually in advance.
 
    ```shell
-   pip install -e .
+   python3 -m pip install -e .
    ```
 
 ## Another option: Docker Image

--- a/docs/en/tools/pytorch2onnx.md
+++ b/docs/en/tools/pytorch2onnx.md
@@ -26,7 +26,7 @@
 2. Install onnx and onnxruntime
 
   ```shell
-  pip install onnx onnxruntime==1.5.1
+  python3 -m pip install onnx onnxruntime==1.5.1
   ```
 
 ### Usage
@@ -78,7 +78,7 @@ We prepare a tool `tools/deployment/test.py` to evaluate ONNX models with ONNXRu
 - Install onnx and onnxruntime-gpu
 
   ```shell
-  pip install onnx onnxruntime-gpu
+  python3 -m pip install onnx onnxruntime-gpu
   ```
 
 ### Usage

--- a/docs/en/tools/visualization.md
+++ b/docs/en/tools/visualization.md
@@ -131,7 +131,7 @@ python tools/visualizations/vis_lr.py configs/repvgg/repvgg-B3g4_4xb64-autoaug-l
 
 ## Class Activation Map Visualization
 
-MMClassification provides `tools\visualizations\vis_cam.py` tool to visualize class activation map. Please use `pip install "grad-cam>=1.3.6"` command to install [pytorch-grad-cam](https://github.com/jacobgil/pytorch-grad-cam).
+MMClassification provides `tools\visualizations\vis_cam.py` tool to visualize class activation map. Please use `python3 -m pip install "grad-cam>=1.3.6"` command to install [pytorch-grad-cam](https://github.com/jacobgil/pytorch-grad-cam).
 
 The supported methods are as follows:
 

--- a/docs/en/tutorials/MMClassification_python.ipynb
+++ b/docs/en/tutorials/MMClassification_python.ipynb
@@ -582,7 +582,7 @@
       },
       "source": [
         "# Install mmcv\n",
-        "!pip install mmcv -f https://download.openmmlab.com/mmcv/dist/cu111/torch1.9.0/index.html\n",
+        "!python3 -m pip install mmcv -f https://download.openmmlab.com/mmcv/dist/cu111/torch1.9.0/index.html\n",
         "# !pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu110/torch1.9.0/index.html"
       ],
       "execution_count": null,
@@ -642,7 +642,7 @@
         "%cd mmclassification/\n",
         "\n",
         "# Install MMClassification from source\n",
-        "!pip install -e . "
+        "!python3 -m pip install -e . "
       ],
       "execution_count": null,
       "outputs": [

--- a/docs/en/tutorials/MMClassification_tools.ipynb
+++ b/docs/en/tutorials/MMClassification_tools.ipynb
@@ -238,7 +238,7 @@
       },
       "source": [
         "# Install mmcv\n",
-        "!pip install mmcv -f https://download.openmmlab.com/mmcv/dist/cu111/torch1.9.0/index.html\n",
+        "!python3 -m pip install mmcv -f https://download.openmmlab.com/mmcv/dist/cu111/torch1.9.0/index.html\n",
         "# !pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu111/torch1.9.0/index.html"
       ],
       "execution_count": null,
@@ -298,7 +298,7 @@
         "%cd mmclassification/\n",
         "\n",
         "# Install MMClassification from source\n",
-        "!pip install -e . "
+        "!python3 -m pip install -e . "
       ],
       "execution_count": null,
       "outputs": [

--- a/docs/zh_CN/community/CONTRIBUTING.md
+++ b/docs/zh_CN/community/CONTRIBUTING.md
@@ -39,7 +39,7 @@ pre-commit hook 的配置文件位于 [.pre-commit-config](https://github.com/op
 在你克隆仓库后，你需要按照如下步骤安装并初始化 pre-commit hook。
 
 ```shell
-pip install -U pre-commit
+python3 -m pip install -U pre-commit
 ```
 
 在仓库文件夹中执行

--- a/docs/zh_CN/install.md
+++ b/docs/zh_CN/install.md
@@ -83,7 +83,7 @@ MMClassification 和 MMCV 的适配关系如下，请安装正确版本的 MMCV 
    一个更好的选择是使用 [MIM](https://github.com/open-mmlab/mim) 来自动选择适合你的 mmcv-full 版本。在使用 MIM 安装 MMClassification 的时候，它就会自动完成 mmcv-full 的安装。
 
    ```shell
-   pip install openmim
+   python3 -m pip install openmim
    ```
 
 ## 安装 MMClassification 库
@@ -97,7 +97,7 @@ MMClassification 和 MMCV 的适配关系如下，请安装正确版本的 MMCV 
 
 如果你已经安装了 MIM，那么只需要使用 `mim install mmcls` 命令来安装 MMClassification。MIM 将会根据你的环境选择安装合适的 mmcv-full 版本。另外，MIM 还提供了一系列其他功能来协助进行训练、参数搜索及模型筛选等。
 
-或者，你可以直接通过 pip 来安装，使用 `pip install mmcls` 命令。这种情况下，如果你希望使用 mmcv-full，那么需要提前手动安装 mmcv-full。
+或者，你可以直接通过 pip 来安装，使用 `python3 -m pip install mmcls` 命令。这种情况下，如果你希望使用 mmcv-full，那么需要提前手动安装 mmcv-full。
 
 ### 基于 MMClassification 进行开发
 
@@ -129,7 +129,7 @@ MMClassification 和 MMCV 的适配关系如下，请安装正确版本的 MMCV 
    或者使用 pip，如果你希望使用 mmcv-full，你需要提前手动安装。
 
    ```shell
-   pip install -e .
+   python3 -m pip install -e .
    ```
 
 ## 利用 Docker 镜像安装 MMClassification

--- a/docs/zh_CN/tools/pytorch2onnx.md
+++ b/docs/zh_CN/tools/pytorch2onnx.md
@@ -20,7 +20,7 @@
 2. 安装 onnx 和 onnxruntime。
 
   ```shell
-  pip install onnx onnxruntime==1.5.1
+  python3 -m pip install onnx onnxruntime==1.5.1
   ```
 
 ### 使用方法

--- a/docs/zh_CN/tools/visualization.md
+++ b/docs/zh_CN/tools/visualization.md
@@ -134,7 +134,7 @@ python tools/visualizations/vis_lr.py configs/repvgg/repvgg-B3g4_4xb64-autoaug-l
 
 ## 类别激活图可视化
 
-MMClassification 提供 `tools\visualizations\vis_cam.py` 工具来可视化类别激活图。请使用 `pip install "grad-cam>=1.3.6"` 安装依赖的 [pytorch-grad-cam](https://github.com/jacobgil/pytorch-grad-cam)。
+MMClassification 提供 `tools\visualizations\vis_cam.py` 工具来可视化类别激活图。请使用 `python3 -m pip install "grad-cam>=1.3.6"` 安装依赖的 [pytorch-grad-cam](https://github.com/jacobgil/pytorch-grad-cam)。
 
 目前支持的方法有：
 

--- a/docs/zh_CN/tutorials/MMClassification_python_cn.ipynb
+++ b/docs/zh_CN/tutorials/MMClassification_python_cn.ipynb
@@ -582,7 +582,7 @@
       },
       "source": [
         "# 安装 mmcv\n",
-        "!pip install mmcv -f https://download.openmmlab.com/mmcv/dist/cu111/torch1.9.0/index.html\n",
+        "!python3 -m pip install mmcv -f https://download.openmmlab.com/mmcv/dist/cu111/torch1.9.0/index.html\n",
         "# !pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu110/torch1.9.0/index.html"
       ],
       "execution_count": 17,
@@ -642,7 +642,7 @@
         "%cd mmclassification/\n",
         "\n",
         "# 从源码安装 MMClassification\n",
-        "!pip install -e . "
+        "!python3 -m pip install -e . "
       ],
       "execution_count": 12,
       "outputs": [

--- a/docs/zh_CN/tutorials/MMClassification_tools_cn.ipynb
+++ b/docs/zh_CN/tutorials/MMClassification_tools_cn.ipynb
@@ -238,7 +238,7 @@
       },
       "source": [
         "# 安装 mmcv\n",
-        "!pip install mmcv -f https://download.openmmlab.com/mmcv/dist/cu111/torch1.9.0/index.html\n",
+        "!python3 -m pip install mmcv -f https://download.openmmlab.com/mmcv/dist/cu111/torch1.9.0/index.html\n",
         "# !pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cu111/torch1.9.0/index.html"
       ],
       "execution_count": 6,
@@ -298,7 +298,7 @@
         "%cd mmclassification/\n",
         "\n",
         "# 从源码安装 MMClassification\n",
-        "!pip install -e . "
+        "!python3 -m pip install -e . "
       ],
       "execution_count": 7,
       "outputs": [


### PR DESCRIPTION
## Motivation

Fix python requirements install description to avoid Python version problem. They are different:
```shell
(base) khj@khj:~/mmdeploy$ python3 -m pip --version
pip 21.2.4 from /mnt/d/khj/miniconda3/lib/python3.9/site-packages/pip (python 3.9)
(base) khj@khj:~/mmdeploy$ pip --version
pip 22.0.4 from /mnt/d/khj/.local/lib/python3.8/site-packages/pip (python 3.8)
```

same as https://github.com/open-mmlab/mmdeploy/pull/341