### PR TITLE
[BUG] Add 'return self' statement in end of model.train

### DIFF
--- a/mmcls/models/backbones/base_backbone.py
+++ b/mmcls/models/backbones/base_backbone.py
@@ -31,3 +31,4 @@ class BaseBackbone(BaseModule, metaclass=ABCMeta):
             mode (bool): Whether it is train_mode or test_mode
         """
         super(BaseBackbone, self).train(mode)
+        return self

--- a/mmcls/models/backbones/convmixer.py
+++ b/mmcls/models/backbones/convmixer.py
@@ -167,6 +167,7 @@ class ConvMixer(BaseBackbone):
     def train(self, mode=True):
         super(ConvMixer, self).train(mode)
         self._freeze_stages()
+        return self
 
     def _freeze_stages(self):
         for i in range(self.frozen_stages):

--- a/mmcls/models/backbones/convnext.py
+++ b/mmcls/models/backbones/convnext.py
@@ -366,3 +366,4 @@ class ConvNeXt(BaseBackbone):
     def train(self, mode=True):
         super(ConvNeXt, self).train(mode)
         self._freeze_stages()
+        return self

--- a/mmcls/models/backbones/cspnet.py
+++ b/mmcls/models/backbones/cspnet.py
@@ -392,6 +392,7 @@ class CSPNet(BaseModule):
             for m in self.modules():
                 if isinstance(m, _BatchNorm):
                     m.eval()
+        return self
 
     def forward(self, x):
         outs = []

--- a/mmcls/models/backbones/davit.py
+++ b/mmcls/models/backbones/davit.py
@@ -797,6 +797,7 @@ class DaViT(BaseBackbone):
                 # trick: eval have effect on BatchNorm only
                 if isinstance(m, _BatchNorm):
                     m.eval()
+        return self
 
     def _freeze_stages(self):
         if self.frozen_stages >= 0:

--- a/mmcls/models/backbones/densenet.py
+++ b/mmcls/models/backbones/densenet.py
@@ -330,3 +330,4 @@ class DenseNet(BaseBackbone):
     def train(self, mode=True):
         super(DenseNet, self).train(mode)
         self._freeze_stages()
+        return self

--- a/mmcls/models/backbones/edgenext.py
+++ b/mmcls/models/backbones/edgenext.py
@@ -396,3 +396,4 @@ class EdgeNeXt(BaseBackbone):
     def train(self, mode=True):
         super(EdgeNeXt, self).train(mode)
         self._freeze_stages()
+        return self

--- a/mmcls/models/backbones/efficientformer.py
+++ b/mmcls/models/backbones/efficientformer.py
@@ -71,6 +71,7 @@ class AttentionWithBias(BaseModule):
             del self.ab
         else:
             self.ab = self.attention_biases[:, self.attention_bias_idxs]
+        return self
 
     def forward(self, x):
         """forward function.
@@ -604,3 +605,4 @@ class EfficientFormer(BaseBackbone):
     def train(self, mode=True):
         super(EfficientFormer, self).train(mode)
         self._freeze_stages()
+        return self

--- a/mmcls/models/backbones/efficientnet.py
+++ b/mmcls/models/backbones/efficientnet.py
@@ -408,3 +408,4 @@ class EfficientNet(BaseBackbone):
             for m in self.modules():
                 if isinstance(m, nn.BatchNorm2d):
                     m.eval()
+        return self

--- a/mmcls/models/backbones/efficientnet_v2.py
+++ b/mmcls/models/backbones/efficientnet_v2.py
@@ -341,3 +341,4 @@ class EfficientNetV2(BaseBackbone):
             for m in self.modules():
                 if isinstance(m, nn.BatchNorm2d):
                     m.eval()
+        return self

--- a/mmcls/models/backbones/hornet.py
+++ b/mmcls/models/backbones/hornet.py
@@ -457,6 +457,7 @@ class HorNet(BaseBackbone):
     def train(self, mode=True):
         super(HorNet, self).train(mode)
         self._freeze_stages()
+        return self
 
     def _freeze_stages(self):
         for i in range(0, self.frozen_stages + 1):

--- a/mmcls/models/backbones/hrnet.py
+++ b/mmcls/models/backbones/hrnet.py
@@ -540,6 +540,7 @@ class HRNet(BaseModule):
                 # trick: eval have effect on BatchNorm only
                 if isinstance(m, _BatchNorm):
                     m.eval()
+        return self
 
     def parse_arch(self, arch, extra=None):
         if extra is not None:

--- a/mmcls/models/backbones/levit.py
+++ b/mmcls/models/backbones/levit.py
@@ -189,6 +189,7 @@ class Attention(BaseModule):
             del self.ab
         else:
             self.ab = self.attention_biases[:, self.attention_bias_idxs]
+        return self
 
     def forward(self, x):  # x (B,N,C)
         B, N, C = x.shape  # 2 196 128
@@ -302,6 +303,7 @@ class AttentionSubsample(nn.Sequential):
             del self.ab
         else:
             self.ab = self.attention_biases[:, self.attention_bias_idxs]
+        return self
 
     def forward(self, x):
         B, N, C = x.shape

--- a/mmcls/models/backbones/mobilenet_v2.py
+++ b/mmcls/models/backbones/mobilenet_v2.py
@@ -262,3 +262,4 @@ class MobileNetV2(BaseBackbone):
             for m in self.modules():
                 if isinstance(m, _BatchNorm):
                     m.eval()
+        return self

--- a/mmcls/models/backbones/mobilenet_v3.py
+++ b/mmcls/models/backbones/mobilenet_v3.py
@@ -215,3 +215,4 @@ class MobileNetV3(BaseBackbone):
             for m in self.modules():
                 if isinstance(m, _BatchNorm):
                     m.eval()
+        return self

--- a/mmcls/models/backbones/mobileone.py
+++ b/mmcls/models/backbones/mobileone.py
@@ -505,6 +505,7 @@ class MobileOne(BaseBackbone):
             for m in self.modules():
                 if isinstance(m, _BatchNorm):
                     m.eval()
+        return self
 
     def switch_to_deploy(self):
         """switch the model to deploy mode, which has smaller amount of

--- a/mmcls/models/backbones/mobilevit.py
+++ b/mmcls/models/backbones/mobilevit.py
@@ -417,6 +417,7 @@ class MobileViT(BaseBackbone):
     def train(self, mode=True):
         super(MobileViT, self).train(mode)
         self._freeze_stages()
+        return self
 
     def forward(self, x):
         x = self.stem(x)

--- a/mmcls/models/backbones/poolformer.py
+++ b/mmcls/models/backbones/poolformer.py
@@ -414,3 +414,4 @@ class PoolFormer(BaseBackbone):
     def train(self, mode=True):
         super(PoolFormer, self).train(mode)
         self._freeze_stages()
+        return self

--- a/mmcls/models/backbones/repvgg.py
+++ b/mmcls/models/backbones/repvgg.py
@@ -614,6 +614,7 @@ class RepVGG(BaseBackbone):
             for m in self.modules():
                 if isinstance(m, _BatchNorm):
                     m.eval()
+        return self
 
     def switch_to_deploy(self):
         for m in self.modules():

--- a/mmcls/models/backbones/resnet.py
+++ b/mmcls/models/backbones/resnet.py
@@ -654,6 +654,7 @@ class ResNet(BaseBackbone):
                 # trick: eval have effect on BatchNorm only
                 if isinstance(m, _BatchNorm):
                     m.eval()
+        return self
 
 
 @MODELS.register_module()

--- a/mmcls/models/backbones/shufflenet_v1.py
+++ b/mmcls/models/backbones/shufflenet_v1.py
@@ -319,3 +319,4 @@ class ShuffleNetV1(BaseBackbone):
             for m in self.modules():
                 if isinstance(m, _BatchNorm):
                     m.eval()
+        return self

--- a/mmcls/models/backbones/shufflenet_v2.py
+++ b/mmcls/models/backbones/shufflenet_v2.py
@@ -303,3 +303,4 @@ class ShuffleNetV2(BaseBackbone):
             for m in self.modules():
                 if isinstance(m, nn.BatchNorm2d):
                     m.eval()
+        return self

--- a/mmcls/models/backbones/swin_transformer.py
+++ b/mmcls/models/backbones/swin_transformer.py
@@ -493,6 +493,7 @@ class SwinTransformer(BaseBackbone):
                 # trick: eval have effect on BatchNorm only
                 if isinstance(m, _BatchNorm):
                     m.eval()
+        return self
 
     def _prepare_abs_pos_embed(self, state_dict, prefix, *args, **kwargs):
         name = prefix + 'absolute_pos_embed'

--- a/mmcls/models/backbones/swin_transformer_v2.py
+++ b/mmcls/models/backbones/swin_transformer_v2.py
@@ -520,6 +520,7 @@ class SwinTransformerV2(BaseBackbone):
                 # trick: eval have effect on BatchNorm only
                 if isinstance(m, _BatchNorm):
                     m.eval()
+        return self
 
     def _prepare_abs_pos_embed(self, state_dict, prefix, *args, **kwargs):
         name = prefix + 'absolute_pos_embed'

--- a/mmcls/models/backbones/tinyvit.py
+++ b/mmcls/models/backbones/tinyvit.py
@@ -767,3 +767,4 @@ class TinyViT(BaseBackbone):
     def train(self, mode=True):
         super(TinyViT, self).train(mode)
         self._freeze_stages()
+        return self

--- a/mmcls/models/backbones/van.py
+++ b/mmcls/models/backbones/van.py
@@ -394,6 +394,7 @@ class VAN(BaseBackbone):
                 # trick: eval have effect on BatchNorm only
                 if isinstance(m, _BatchNorm):
                     m.eval()
+        return self
 
     def _freeze_stages(self):
         for i in range(0, self.frozen_stages + 1):

--- a/mmcls/models/backbones/vgg.py
+++ b/mmcls/models/backbones/vgg.py
@@ -181,3 +181,4 @@ class VGG(BaseBackbone):
                 # trick: eval have effect on BatchNorm only
                 if isinstance(m, _BatchNorm):
                     m.eval()
+        return self

--- a/mmcls/models/backbones/vig.py
+++ b/mmcls/models/backbones/vig.py
@@ -671,6 +671,7 @@ class Vig(BaseBackbone):
                 # trick: eval have effect on BatchNorm only
                 if isinstance(m, _BatchNorm):
                     m.eval()
+        return self
 
 
 @MODELS.register_module()
@@ -850,3 +851,4 @@ class PyramidVig(BaseBackbone):
                 # trick: eval have effect on BatchNorm only
                 if isinstance(m, _BatchNorm):
                     m.eval()
+        return self

--- a/mmcls/models/utils/attention.py
+++ b/mmcls/models/utils/attention.py
@@ -855,6 +855,7 @@ class LeAttention(BaseModule):
             del self.ab
         else:
             self.ab = self.attention_biases[:, self.attention_bias_idxs]
+        return self
 
     def forward(self, x):  # x (B,N,C)
         B, N, _ = x.shape


### PR DESCRIPTION


## Motivation

fix the bug in https://github.com/open-mmlab/mmclassification/issues/1383

## Modification

Add `return self` statement in end of `model.train`


## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
