### PR TITLE
adapt loss to full mask

### DIFF
--- a/mmcls/models/heads/multi_task_head.py
+++ b/mmcls/models/heads/multi_task_head.py
@@ -23,7 +23,8 @@ def loss_convertor(loss_func, task_name):
                 task_data_samples.append(data_sample.get(task_name))
 
         if len(task_data_samples) == 0:
-            return {'loss': torch.tensor(0.), 'mask_size': torch.tensor(0.)}
+            loss = (inputs[0] * 0).sum()
+            return {'loss': loss, 'mask_size': torch.tensor(0.)}
 
         # Mask the inputs of the task
         def mask_inputs(inputs, mask):


### PR DESCRIPTION
in the pull request #1229 , for the extreme case that we have a full-mask we do for the loss = 0 which will cause problems to calculate the gradient of the loss. here i  use the torch vector of the image to create a loss =0