### PR TITLE
[Feat] Add vit-base-16 pretrain weight on Bamboo

### DIFF
--- a/tools/model_converters/bamboo_to_mmpretrain.py
+++ b/tools/model_converters/bamboo_to_mmpretrain.py
@@ -1,0 +1,75 @@
+# Copyright (c) OpenMMLab. All rights reserved.
+import argparse
+import os.path as osp
+from collections import OrderedDict
+
+import mmengine
+import torch
+from mmengine.runner import CheckpointLoader
+
+
+def convert_bamboo_vit(ckpt):
+
+    new_ckpt = OrderedDict()
+    weight = ckpt['state_dict']
+
+    for k, v in list(weight.items()):
+        if k.startswith('module.'):
+            k = k[7:]
+        new_v = v
+        if k.startswith('head'):  # TODO
+            new_k = k.replace('head.', 'head.fc.')
+            new_ckpt[new_k] = new_v
+            continue
+        elif k.startswith('patch_embed'):
+            if 'proj.' in k:
+                new_k = k.replace('proj.', 'projection.')
+            else:
+                new_k = k
+        elif k.startswith('blocks'):
+            new_k = k.replace('blocks.', 'layers.')
+            if 'norm1' in k:
+                new_k = new_k.replace('norm1', 'ln1')
+            elif 'norm2' in k:
+                new_k = new_k.replace('norm2', 'ln2')
+            elif 'mlp.fc1' in k:
+                new_k = new_k.replace('mlp.fc1', 'ffn.layers.0.0')
+            elif 'mlp.fc2' in k:
+                new_k = new_k.replace('mlp.fc2', 'ffn.layers.1')
+
+        elif k.startswith('norm.'):
+            new_k = k.replace('norm.', 'ln1.')
+        else:
+            new_k = k
+
+        if not new_k.startswith('head'):
+            new_k = 'backbone.' + new_k
+        new_ckpt[new_k] = new_v
+    return new_ckpt
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Convert keys in pretrained bamboo vit-base-p16 '
+        'models to mmpretrain style.')
+    parser.add_argument('src', help='src model path or url')
+    # The dst path must be a full path of the new checkpoint.
+    parser.add_argument('dst', help='save path')
+    args = parser.parse_args()
+
+    checkpoint = CheckpointLoader.load_checkpoint(args.src, map_location='cpu')
+
+    if 'model' in checkpoint:
+        state_dict = checkpoint['model']
+    else:
+        state_dict = checkpoint
+
+    weight = convert_bamboo_vit(state_dict)
+    mmengine.mkdir_or_exist(osp.dirname(args.dst))
+    torch.save(weight, args.dst)
+
+    print('Done!!')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

Convert vit-base-16 pretrain weight on [Bamboo-CLS](https://github.com/zhangyuanhan-ai/bamboo) to mmpretrain.

## Modification

Please briefly describe what modification is made in this PR.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

convert weight:

```bash
python tools/model_converters/bamboo_to_mmpretrain.py PATH/TO/OFFICIAL/Bamboo_v0-1_ViT-B16.pth vit-base-p16_bamboo-cls-pre-3rdparty.pth
```

load weight:

```python
pretrained = 'PATH/TO/vit-base-p16_bamboo-cls-pre-3rdparty.pth'

model = dict(
    type='ImageClassifier',
    backbone=dict(
        type='VisionTransformer',
        arch='base',
        img_size=224,
        patch_size=16,
        drop_path_rate=0.1,
        out_type='avg_featmap',
        final_norm=True,
        init_cfg=dict(type='Pretrained', 
                      checkpoint=pretrained,
                      prefix='backbone')),
    neck=None,
    head=dict(
        type='LinearClsHead',
        num_classes=1000,
        in_channels=768,
        loss=dict(
            type='LabelSmoothLoss', label_smooth_val=0.1, mode='original'),
        init_cfg=[dict(type='TruncNormal', layer='Linear', std=2e-5)]),
    train_cfg=dict(augments=[
        dict(type='Mixup', alpha=0.8),
        dict(type='CutMix', alpha=1.0)
    ]))
```



## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.

