### PR TITLE
[Fix] Fix multi-task-head loss potential bug

### DIFF
--- a/mmpretrain/models/heads/multi_task_head.py
+++ b/mmpretrain/models/heads/multi_task_head.py
@@ -22,7 +22,8 @@ def loss_convertor(loss_func, task_name):
                 task_data_samples.append(data_sample.get(task_name))
 
         if len(task_data_samples) == 0:
-            return {'loss': torch.tensor(0.), 'mask_size': torch.tensor(0.)}
+            loss = (inputs[0] * 0).sum()
+            return {'loss': loss, 'mask_size': torch.tensor(0.)}
 
         # Mask the inputs of the task
         def mask_inputs(inputs, mask):

--- a/mmpretrain/models/heads/multi_task_head.py
+++ b/mmpretrain/models/heads/multi_task_head.py
@@ -22,6 +22,8 @@ def loss_convertor(loss_func, task_name):
                 task_data_samples.append(data_sample.get(task_name))
 
         if len(task_data_samples) == 0:
+            # This makes it possible to perform loss.backward when a
+            # task does not have gt_labels within a batch.
             loss = (inputs[0] * 0).sum()
             return {'loss': loss, 'mask_size': torch.tensor(0.)}
 


### PR DESCRIPTION
## Motivation

in the pull request https://github.com/open-mmlab/mmpretrain/pull/1229 , for the extreme case that we have a full-mask we do for the loss = 0 which will cause problems to calculate the gradient of the loss. here i use the torch vector of the image to create a loss =0

https://github.com/open-mmlab/mmpretrain/issues/1393

the same as https://github.com/open-mmlab/mmpretrain/pull/1426

## Modification

Please briefly describe what modification is made in this PR.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
