### PR TITLE
[Fix] Fix incorrect config path of mobilenet

### DIFF
--- a/configs/mobilenet_v3/mobilenet-v3-small_8xb16_cifar10.py
+++ b/configs/mobilenet_v3/mobilenet-v3-small_8xb16_cifar10.py
@@ -1,5 +1,5 @@
 _base_ = [
-    '../_base_/models/mobilenet-v3-small_cifar.py',
+    '../_base_/models/mobilenet_v3_small_cifar.py',
     '../_base_/datasets/cifar10_bs16.py',
     '../_base_/schedules/cifar10_bs128.py', '../_base_/default_runtime.py'
 ]


### PR DESCRIPTION
## Motivation

Fix incorrect config path of mobilenet.

## Modification

Provide the correct configuration path.

## BC-breaking (Optional)

Not affect.


## Use cases (Optional)

Not affect.
