### PR TITLE
fix: multi task predict for nested heads

### DIFF
--- a/mmpretrain/models/heads/multi_task_head.py
+++ b/mmpretrain/models/heads/multi_task_head.py
@@ -116,12 +116,28 @@ class MultiTaskHead(BaseModule):
         predictions_dict = dict()
 
         for task_name, head in self.task_heads.items():
-            task_samples = head.predict(feats)
+            task_samples = None
+            if data_samples is not None:
+                task_samples = []
+                for data_sample in data_samples:
+                    if data_sample is None:
+                        task_samples.append(None)
+                    elif task_name in data_sample.tasks:
+                        task_samples.append(data_sample.get(task_name))
+                    else:
+                        task_samples.append(None)
+
+            task_samples = head.predict(feats, task_samples)
             batch_size = len(task_samples)
             predictions_dict[task_name] = task_samples
 
         if data_samples is None:
             data_samples = [MultiTaskDataSample() for _ in range(batch_size)]
+        else:
+            data_samples = [
+                MultiTaskDataSample() if data_sample is None else data_sample
+                for data_sample in data_samples
+            ]
 
         for task_name, task_samples in predictions_dict.items():
             for data_sample, task_sample in zip(data_samples, task_samples):


### PR DESCRIPTION


## Motivation

I faced a problem when playing with multi task following https://github.com/open-mmlab/mmpretrain/pull/1229

* Each head is not called with a data_sample as input (see https://github.com/open-mmlab/mmpretrain/blob/e80418a424aaefb81c95df458216bb3e9af246c4/mmpretrain/models/heads/multi_task_head.py#L119), which will break the process with nested multi_task heads
* when the input data_sample is [MultiTaskDataSample, None] it is not working properly

## Modification

* Reimplement data_sample filtering in multi_task_head predict method
* Add a unit test for predict in a nested scenario

## Use cases 

* Fix the multi-task nested
* I'm working on other use cases like shared layers between multi-tasked heads

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
