### PR TITLE
[Doc] RIFormer's README did not link to its paper properly

### DIFF
--- a/configs/riformer/README.md
+++ b/configs/riformer/README.md
@@ -1,6 +1,6 @@
 # RIFormer
 
-> [RIFormer: Keep Your Vision Backbone Effective But Removing Token Mixer](https://arxiv.org/abs/xxxx.xxxxx)
+> [RIFormer: Keep Your Vision Backbone Effective But Removing Token Mixer](https://arxiv.org/abs/2304.05659)
 
 <!-- [ALGORITHM] -->
 


### PR DESCRIPTION
## Motivation

RIFormer's README did not link to its paper properly

## Modification

Add the correct website to Readme Doc.