### PR TITLE
Incorrect stage freeze on RIFormer Model

### DIFF
--- a/configs/riformer/README.md
+++ b/configs/riformer/README.md
@@ -1,6 +1,6 @@
 # RIFormer
 
-> [RIFormer: Keep Your Vision Backbone Effective But Removing Token Mixer](https://arxiv.org/abs/xxxx.xxxxx)
+> [RIFormer: Keep Your Vision Backbone Effective But Removing Token Mixer](https://arxiv.org/abs/2304.05659)
 
 <!-- [ALGORITHM] -->
 

--- a/mmpretrain/models/backbones/riformer.py
+++ b/mmpretrain/models/backbones/riformer.py
@@ -202,7 +202,7 @@ class RIFormer(BaseBackbone):
             [stage1, downsampling, stage2, downsampling, stage3, downsampling, stage4]
             Defaults to -1, means the last stage.
         frozen_stages (int): Stages to be frozen (all param fixed).
-            Defaults to 0, which means not freezing any parameters.
+            Defaults to -1, which means not freezing any parameters.
         deploy (bool): Whether to switch the model structure to
             deployment mode. Default: False.
         init_cfg (dict, optional): Initialization config dict
@@ -259,7 +259,7 @@ class RIFormer(BaseBackbone):
                  drop_rate=0.,
                  drop_path_rate=0.,
                  out_indices=-1,
-                 frozen_stages=0,
+                 frozen_stages=-1,
                  init_cfg=None,
                  deploy=False):
 
@@ -366,7 +366,7 @@ class RIFormer(BaseBackbone):
             for param in self.patch_embed.parameters():
                 param.requires_grad = False
 
-        for i in range(self.frozen_stages):
+        for i in range(0, self.frozen_stages + 1):
             # Include both block and downsample layer.
             module = self.network[i]
             module.eval()


### PR DESCRIPTION
## Motivation

The reproduce code of RIFormer seems to be incorrect when handling stage freeze. This may cause an incorrect result.
Add the correct arxiv website of RIFormer to Readme.

## Modification

Repair the index in for loop of freeze_stage. Change the default value of freeze_stage to -1.
Add the paper pdf website to its Readme.


## BC-breaking (Optional)

I'm uncertain whether this modification will disrupt the standardization of the 'freeze_stage' parameter in the mmpretrain project.