### PR TITLE
[FIX] Fix bug of vis_cam when using swin

### DIFF
--- a/tools/visualization/vis_cam.py
+++ b/tools/visualization/vis_cam.py
@@ -199,7 +199,8 @@ def get_default_traget_layers(model, args):
         num_extra_tokens = args.num_extra_tokens or getattr(
             model.backbone, 'num_extra_tokens', 1)
 
-        out_type = getattr(model.backbone, 'out_type')
+        # models like swin have no attr 'out_type', set out_type to avg_featmap
+        out_type = getattr(model.backbone, 'out_type', 'avg_featmap')
         if out_type == 'cls_token' or num_extra_tokens > 0:
             # Assume the backbone feature is class token.
             name, layer = norm_layers[-3]


### PR DESCRIPTION
## Motivation

Fix bug of vis_cam when using swin refer to https://github.com/open-mmlab/mmpretrain/issues/1580

## Modification

set default out_type to avg_featmap


## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
