### PR TITLE
[Fix] Fix calculation errors on ARM chip

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,8 @@ repos:
     rev: 4.0.1
     hooks:
       - id: flake8
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+  - repo: https://github.com/zhouzaida/isort
+    rev: 5.12.1
     hooks:
       - id: isort
   - repo: https://github.com/pre-commit/mirrors-yapf

--- a/mmcls/models/losses/accuracy.py
+++ b/mmcls/models/losses/accuracy.py
@@ -1,9 +1,12 @@
 # Copyright (c) OpenMMLab. All rights reserved.
+import platform
 from numbers import Number
 
 import numpy as np
 import torch
 import torch.nn as nn
+
+from mmcls.utils import auto_select_device
 
 
 def accuracy_numpy(pred, target, topk=(1, ), thrs=0.):
@@ -112,6 +115,12 @@ def accuracy(pred, target, topk=1, thrs=0.):
                  if isinstance(x, np.ndarray) else x)
     pred = to_tensor(pred)
     target = to_tensor(target)
+    if platform.machine() == 'aarch64':
+        # ARM chip with low version GCC version may cause calculation errors,
+        # attempt to calculate on cuda or npu.
+        # reference: https://github.com/pytorch/pytorch/issues/75411
+        pred = pred.to(auto_select_device())
+        target = target.to(auto_select_device())
 
     res = accuracy_torch(pred, target, topk, thrs)
 


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

ARM chip with low version GCC version may cause calculation errors.
reference: https://github.com/pytorch/pytorch/issues/75411
This leads to incorrect accuracy calculations, even though the model is correctly trained.

## Modification

When the model is trained on the arm chip, try to calculate the accuracy on cuda/npu to avoid calculation errors caused by sum operations.

## BC-breaking (Optional)

Not affected.

## Use cases (Optional)

We have verified the correctness on some configs, such as resnet18_8xb16_cifar10.py and resnet152_8xb16_cifar10.py
