### PR TITLE
[Feature] Support OK-VQA dataset

### DIFF
--- a/configs/_base_/datasets/coco_okvqa.py
+++ b/configs/_base_/datasets/coco_okvqa.py
@@ -1,0 +1,75 @@
+# data settings
+
+data_preprocessor = dict(
+    mean=[122.770938, 116.7460125, 104.09373615],
+    std=[68.5005327, 66.6321579, 70.32316305],
+    to_rgb=True,
+)
+
+train_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(
+        type='RandomResizedCrop',
+        scale=384,
+        interpolation='bicubic',
+        backend='pillow'),
+    dict(
+        type='PackInputs',
+        algorithm_keys=['question', 'gt_answer', 'gt_answer_weight'],
+        meta_keys=['question_id', 'image_id'],
+    ),
+]
+
+test_pipeline = [
+    dict(type='LoadImageFromFile'),
+    dict(
+        type='Resize',
+        scale=(480, 480),
+        interpolation='bicubic',
+        backend='pillow'),
+    dict(
+        type='CleanCaption',
+        keys=['question'],
+    ),
+    dict(
+        type='PackInputs',
+        algorithm_keys=['question', 'gt_answer', 'gt_answer_weight'],
+        meta_keys=['question_id', 'image_id'],
+    ),
+]
+
+train_dataloader = dict(
+    batch_size=16,
+    num_workers=8,
+    dataset=dict(
+        type='COCOVQA',
+        data_root='data/coco',
+        data_prefix='images/train2014',
+        question_file=
+        'annotations/okvqa_OpenEnded_mscoco_train2014_questions.json',
+        ann_file='annotations/okvqa_mscoco_train2014_annotations.json',
+        pipeline=train_pipeline),
+    sampler=dict(type='DefaultSampler', shuffle=True),
+    persistent_workers=True,
+    drop_last=True,
+)
+
+val_dataloader = dict(
+    batch_size=16,
+    num_workers=8,
+    dataset=dict(
+        type='COCOVQA',
+        data_root='data/coco',
+        data_prefix='images/val2014',
+        question_file=
+        'annotations/okvqa_OpenEnded_mscoco_val2014_questions.json',
+        ann_file='annotations/okvqa_mscoco_val2014_annotations.json',
+        pipeline=test_pipeline),
+    sampler=dict(type='DefaultSampler', shuffle=False),
+    persistent_workers=True,
+)
+
+val_evaluator = dict(type='VQAAcc')
+
+test_dataloader = val_dataloader
+test_evaluator = val_evaluator

--- a/configs/blip/README.md
+++ b/configs/blip/README.md
@@ -62,7 +62,7 @@ python tools/test.py configs/blip/blip-base_8xb32_caption.py https://download.op
 
 | Model                      | Params (M) | Accuracy |                Config                |                                                       Download                                                        |
 | :------------------------- | :--------: | :------: | :----------------------------------: | :-------------------------------------------------------------------------------------------------------------------: |
-| `blip-base_3rdparty_vqa`\* |   361.48   |  40.59   | [config](./blip-base_8xb32_okvqa.py) | [model](https://download.openmmlab.com/mmclassification/v1/blip/blip-base_3rdparty-capflit_vqa_20230505-81488941.pth) |
+| `blip-base_3rdparty_vqa`\* |   361.48   |  40.59#  | [config](./blip-base_8xb32_okvqa.py) | [model](https://download.openmmlab.com/mmclassification/v1/blip/blip-base_3rdparty-capflit_vqa_20230505-81488941.pth) |
 
 ### Image-To-Text Retrieval on COCO
 
@@ -83,6 +83,8 @@ python tools/test.py configs/blip/blip-base_8xb32_caption.py https://download.op
 | `blip-base_3rdparty_nlvr`\* |   259.37   |   82.33   | [config](./blip-base_8xb32_nlvr.py) | [model](https://download.openmmlab.com/mmclassification/v1/blip/blip-base_3rdparty_nlvr_20230427-3b14d33f.pth) |
 
 *Models with * are converted from the [official repo](https://github.com/salesforce/LAVIS). The config files of these models are only for inference. We haven't reprodcue the training results.*
+
+*Results with # denote zero-shot evaluation. The corresponding model hasn't been finetuned on that dataset.*
 
 ## Citation
 

--- a/configs/blip/README.md
+++ b/configs/blip/README.md
@@ -58,6 +58,12 @@ python tools/test.py configs/blip/blip-base_8xb32_caption.py https://download.op
 | :------------------------- | :--------: | :------: | :--------------------------------: | :-------------------------------------------------------------------------------------------------------------------: |
 | `blip-base_3rdparty_vqa`\* |   361.48   |  78.20   | [config](./blip-base_8xb32_vqa.py) | [model](https://download.openmmlab.com/mmclassification/v1/blip/blip-base_3rdparty-capflit_vqa_20230505-81488941.pth) |
 
+### Visual Question Answering on OK-VQA
+
+| Model                      | Params (M) | Accuracy |                Config                |                                                       Download                                                        |
+| :------------------------- | :--------: | :------: | :----------------------------------: | :-------------------------------------------------------------------------------------------------------------------: |
+| `blip-base_3rdparty_vqa`\* |   361.48   |  40.59   | [config](./blip-base_8xb32_okvqa.py) | [model](https://download.openmmlab.com/mmclassification/v1/blip/blip-base_3rdparty-capflit_vqa_20230505-81488941.pth) |
+
 ### Image-To-Text Retrieval on COCO
 
 | Model                            | Params (M) | Recall@1 | Recall@5 |                  Config                  |                                                Download                                                |

--- a/configs/blip/blip-base_8xb32_okvqa.py
+++ b/configs/blip/blip-base_8xb32_okvqa.py
@@ -1,0 +1,75 @@
+_base_ = [
+    '../_base_/datasets/coco_okvqa.py',
+    '../_base_/default_runtime.py',
+]
+
+# model settings
+model = dict(
+    type='BlipVQA',
+    tokenizer=dict(type='BlipTokenizer', name_or_path='bert-base-uncased'),
+    vision_backbone=dict(
+        type='VisionTransformer',
+        arch='b',
+        img_size=480,
+        patch_size=16,
+        out_type='raw'),
+    multimodal_backbone=dict(
+        type='XBertEncoder',
+        med_config=dict(
+            architectures=['BertModel'],
+            attention_probs_dropout_prob=0.1,
+            hidden_act='gelu',
+            hidden_dropout_prob=0.1,
+            hidden_size=768,
+            initializer_range=0.02,
+            intermediate_size=3072,
+            layer_norm_eps=1e-12,
+            max_position_embeddings=512,
+            model_type='bert',
+            num_attention_heads=12,
+            num_hidden_layers=12,
+            pad_token_id=0,
+            add_type_embeddings=False,
+            vocab_size=30524,
+            encoder_width=768,
+            add_cross_attention=True),
+    ),
+    head=dict(
+        type='VQAGenerationHead',
+        decoder=dict(
+            type='XBertLMHeadDecoder',
+            med_config=dict(
+                architectures=['BertModel'],
+                attention_probs_dropout_prob=0.1,
+                hidden_act='gelu',
+                hidden_dropout_prob=0.1,
+                hidden_size=768,
+                initializer_range=0.02,
+                intermediate_size=3072,
+                layer_norm_eps=1e-12,
+                max_position_embeddings=512,
+                model_type='bert',
+                num_attention_heads=12,
+                num_hidden_layers=12,
+                pad_token_id=0,
+                add_type_embeddings=False,
+                vocab_size=30524,
+                encoder_width=768,
+                add_cross_attention=True),
+        ),
+        inference_method='generate',
+    ),
+)
+
+# schedule settings
+optimizer = dict(type='AdamW', lr=2e-5, weight_decay=0.05)
+optim_wrapper = dict(type='OptimWrapper', optimizer=optimizer)
+
+param_scheduler = [dict(type='CosineAnnealingLR', by_epoch=True)]
+
+train_cfg = dict(max_epochs=10, by_epoch=True)
+val_cfg = dict()
+test_cfg = dict()
+
+# runtime settings
+randomness = dict(seed=42)


### PR DESCRIPTION
## Modification

Support `OK-VQA` dataset.

Reuse the dataset file of `COCOVQA`, only need to change the annotation file, so **only need to change the config**.

You can easily download `OK-VQA` annotation file at https://okvqa.allenai.org/download.html
Or you can fetch it from /mnt/petrelfs/share_data/wangyiqin/coco/annotations/

A example config for BLIP zero-shot inference is provided. It perform an ACC of 40.6.
![IrItFDTOEu](https://github.com/open-mmlab/mmpretrain/assets/37479394/cb38f331-3d04-4b7e-988f-0d39b28db0a8)

Example command:
```bash
sh tools/slurm_test.sh <patrition> <jobname> configs/blip/blip-base_8xb32_okvqa.py /mnt/petrelfs/share_data/wangyiqin/blip_ckpt/blip-base_3rdparty-capflit_vqa_20230505-81488941.pth
```