### PR TITLE
[FIX] Fix bug loading IN1k dataset

### DIFF
--- a/mmpretrain/datasets/imagenet.py
+++ b/mmpretrain/datasets/imagenet.py
@@ -117,7 +117,7 @@ class ImageNet(CustomDataset):
             if ann_file == '':
                 _ann_path = fileio.join_path(data_root, 'meta', f'{split}.txt')
                 if fileio.exists(_ann_path):
-                    ann_file = _ann_path
+                    ann_file = fileio.join_path('meta', f'{split}.txt')
 
         super().__init__(
             data_root=data_root,
@@ -210,7 +210,7 @@ class ImageNet21k(CustomDataset):
             if not ann_file:
                 _ann_path = fileio.join_path(data_root, 'meta', f'{split}.txt')
                 if fileio.exists(_ann_path):
-                    ann_file = _ann_path
+                    ann_file = fileio.join_path('meta', f'{split}.txt')
 
         logger = MMLogger.get_current_instance()
 


### PR DESCRIPTION
## Motivation

if there is 'meta/train.txt' in the imagenet dataset folder.

the ann_file would be `data_root/data_root/meta/train.txt`

![image](https://github.com/open-mmlab/mmpretrain/assets/18586273/ecd8b339-fd5a-40ed-8050-1dcd4fc6c4dd)


## Modification

Please briefly describe what modification is made in this PR.


## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
