### PR TITLE
[Docs] fix doc typos

### DIFF
--- a/docs/zh_CN/advanced_guides/modules.md
+++ b/docs/zh_CN/advanced_guides/modules.md
@@ -3,7 +3,7 @@
 在我们的设计中，我们定义一个完整的模型为顶层模块，根据功能的不同，基本几种不同类型的模型组件组成。
 
 - 模型：顶层模块定义了具体的任务类型，例如 `ImageClassifier` 用在图像分类任务中， `MAE` 用在自监督学习中， `ImageToImageRetriever` 用在图像检索中。
-- 主干网络：通常是一个特征提取网络，涵盖了模型直接绝大多数的差异，例如 `ResNet`、`MobileNet`。
+- 主干网络：通常是一个特征提取网络，涵盖了模型之间绝大多数的差异，例如 `ResNet`、`MobileNet`。
 - 颈部：用于连接主干网络和头部的组件，例如 `GlobalAveragePooling`。
 - 头部：用于执行特定任务的组件，例如 `ClsHead`、 `ContrastiveHead`。
 - 损失函数：在头部用于计算损失函数的组件，例如 `CrossEntropyLoss`、`LabelSmoothLoss`。


### PR DESCRIPTION

## Motivation

The English version of the document differs from the Chinese content, and it appears that the Chinese version contains typos caused by using Pinyin.

## Modification

"涵盖了模型直接绝大多数的差异" -> "涵盖了模型之间绝大多数的差异"

English edition:
"backbone: usually a feature extraction network that records the major differences between models, e.g., ResNet, MobileNet."

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
