### PR TITLE
Fix the freezing of cls_token in VisionTransformer

### DIFF
--- a/mmpretrain/models/backbones/vision_transformer.py
+++ b/mmpretrain/models/backbones/vision_transformer.py
@@ -436,7 +436,8 @@ class VisionTransformer(BaseBackbone):
         for param in self.pre_norm.parameters():
             param.requires_grad = False
         # freeze cls_token
-        self.cls_token.requires_grad = False
+        if self.cls_token:
+          self.cls_token.requires_grad = False
         # freeze layers
         for i in range(1, self.frozen_stages + 1):
             m = self.layers[i - 1]


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

An error is raised when calling the method `_freeze_stages` of `VisionTransformer` without `cls_token`. However, we should be able to freeze some layers if the model doesn't contain any `cls_token`.

## Modification

In the method `_freeze_stages` of `VisionTransformer`, freeze the `cls_token` only if it is not `None`.

## BC-breaking (Optional)

No BC-breaking.

## Use cases (Optional)

No new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
