### PR TITLE
[Enhancement] Support training of BLIP2

### DIFF
--- a/configs/blip2/blip2-opt2.7b_8xb32_caption.py
+++ b/configs/blip2/blip2-opt2.7b_8xb32_caption.py
@@ -57,7 +57,7 @@ param_scheduler = [
     )
 ]
 
-train_cfg = dict(by_epocgh=True, max_epochs=10)
+train_cfg = dict(by_epoch=True, max_epochs=10)
 val_cfg = dict()
 test_cfg = dict()
 

--- a/configs/blip2/blip2-opt2.7b_8xb32_caption.py
+++ b/configs/blip2/blip2-opt2.7b_8xb32_caption.py
@@ -57,7 +57,7 @@ param_scheduler = [
     )
 ]
 
-train_cfg = dict(max_epochs=10)
+train_cfg = dict(by_epocgh=True, max_epochs=10)
 val_cfg = dict()
 test_cfg = dict()
 

--- a/mmpretrain/models/backbones/beit.py
+++ b/mmpretrain/models/backbones/beit.py
@@ -304,6 +304,7 @@ class BEiTViT(VisionTransformer):
                  interpolate_mode='bicubic',
                  patch_cfg=dict(),
                  layer_cfgs=dict(),
+                 pre_norm=False,
                  init_cfg=None):
         super(VisionTransformer, self).__init__(init_cfg)
 
@@ -415,6 +416,11 @@ class BEiTViT(VisionTransformer):
             self.layers.append(BEiTTransformerEncoderLayer(**_layer_cfg))
 
         self.frozen_stages = frozen_stages
+        if pre_norm:
+            self.pre_norm = build_norm_layer(norm_cfg, self.embed_dims)
+        else:
+            self.pre_norm = nn.Identity()
+
         self.final_norm = final_norm
         if final_norm:
             self.ln1 = build_norm_layer(norm_cfg, self.embed_dims)

--- a/mmpretrain/models/backbones/beit.py
+++ b/mmpretrain/models/backbones/beit.py
@@ -304,7 +304,6 @@ class BEiTViT(VisionTransformer):
                  interpolate_mode='bicubic',
                  patch_cfg=dict(),
                  layer_cfgs=dict(),
-                 pre_norm=False,
                  init_cfg=None):
         super(VisionTransformer, self).__init__(init_cfg)
 
@@ -355,7 +354,6 @@ class BEiTViT(VisionTransformer):
         else:
             raise ValueError(
                 'with_cls_token must be True when `out_type="cls_token"`.')
-        self.with_cls_token = with_cls_token
 
         # Set position embedding
         self.interpolate_mode = interpolate_mode
@@ -417,11 +415,6 @@ class BEiTViT(VisionTransformer):
             self.layers.append(BEiTTransformerEncoderLayer(**_layer_cfg))
 
         self.frozen_stages = frozen_stages
-        if pre_norm:
-            self.pre_norm = build_norm_layer(norm_cfg, self.embed_dims)
-        else:
-            self.pre_norm = nn.Identity()
-
         self.final_norm = final_norm
         if final_norm:
             self.ln1 = build_norm_layer(norm_cfg, self.embed_dims)

--- a/mmpretrain/models/backbones/beit.py
+++ b/mmpretrain/models/backbones/beit.py
@@ -355,6 +355,7 @@ class BEiTViT(VisionTransformer):
         else:
             raise ValueError(
                 'with_cls_token must be True when `out_type="cls_token"`.')
+        self.with_cls_token = with_cls_token
 
         # Set position embedding
         self.interpolate_mode = interpolate_mode

--- a/mmpretrain/models/multimodal/blip2/Qformer.py
+++ b/mmpretrain/models/multimodal/blip2/Qformer.py
@@ -598,7 +598,8 @@ class BertLMHeadModel(BertPreTrainedModel):
         self.init_weights()
 
     def get_output_embeddings(self):
-        return self.cls.predictions.decoder
+        if self.cls is not None:
+            return self.cls.predictions.decoder
 
     def set_output_embeddings(self, new_embeddings):
         self.cls.predictions.decoder = new_embeddings

--- a/mmpretrain/models/multimodal/blip2/blip2_caption.py
+++ b/mmpretrain/models/multimodal/blip2/blip2_caption.py
@@ -1,5 +1,5 @@
 # Copyright (c) OpenMMLab. All rights reserved.
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 import torch
 from mmengine.model import BaseModel
@@ -95,12 +95,10 @@ class Blip2Caption(BaseModel):
         if hasattr(self, 'register_load_state_dict_post_hook'):
             self.register_load_state_dict_post_hook(self._ignore_llm_keys_hook)
 
-    def forward(
-        self,
-        images: torch.Tensor,
-        data_samples: Optional[List] = None,
-        mode: str = 'loss',
-    ) -> List[DataSample]:
+    def forward(self,
+                images: torch.Tensor,
+                data_samples: Optional[List] = None,
+                mode: str = 'loss'):
         """The unified entry for a forward process in both training and test.
         The method should accept two modes: "predict" and "loss":
 
@@ -120,6 +118,8 @@ class Blip2Caption(BaseModel):
         Returns:
             The return type depends on ``mode``.
             - If ``mode="loss"``, return a dict of tensor.
+            - If ``mode="predict"``, return a list of
+              :obj:`mmpretrain.structures.DataSample`.
         """
         if mode == 'loss':
             return self.loss(images, data_samples)
@@ -127,6 +127,79 @@ class Blip2Caption(BaseModel):
             return self.predict(images, data_samples)
         else:
             raise RuntimeError(f'Invalid mode "{mode}".')
+
+    def loss(self,
+             images: torch.Tensor,
+             data_samples: Optional[list] = None,
+             **kwargs) -> Dict[str, torch.Tensor]:
+        """The forward function in training.
+
+        Args:
+            images (torch.Tensor): The input tensor with shape
+                (N, C, ...) in general.
+            data_samples (List[DataSample], optional): The annotation
+                data of every samples. Defaults to None.
+            **kwargs: Other keyword arguments accepted by the ``loss``
+                method of :attr:`head`.
+
+        Returns:
+            Dict[str, torch.Tensor]: A dictionary of loss components.
+        """
+
+        # extract image features
+        image_embeds = self.ln_vision_backbone(self.vision_backbone(images)[0])
+        image_atts = torch.ones(
+            image_embeds.size()[:-1],
+            dtype=torch.long,
+        ).to(images.device)
+
+        # distill image features to query tokens
+        query_tokens = self.query_tokens.expand(image_embeds.size(0), -1, -1)
+        query_outputs = self.multimodal_backbone.bert(
+            query_embeds=query_tokens,
+            encoder_hidden_states=image_embeds,
+            encoder_attention_mask=image_atts,
+            return_dict=True,
+        )
+        inputs_opt = self.vision_neck([query_outputs.last_hidden_state])
+        attns_opt = torch.ones(
+            inputs_opt.size()[:-1], dtype=torch.long).to(images.device)
+
+        self.tokenizer.padding_side = "right"
+
+        prompt = [
+            data_sample.gt_caption + '\n' for data_sample in data_samples
+        ]
+
+        opt_tokens = self.tokenizer(
+            prompt, return_tensors='pt').to(images.device)
+        attention_mask = torch.cat([attns_opt, opt_tokens.attention_mask],
+                                   dim=1)
+
+        targets = opt_tokens.input_ids.masked_fill(
+            opt_tokens.input_ids == self.tokenizer.pad_token_id, -100)
+        if self.prompt:
+            targets[:, :self.prompt_length] = -100
+
+        empty_targets = (
+            torch.ones(attns_opt.size(),
+                       dtype=torch.long).to(images.device).fill_(-100))
+        targets = torch.cat([empty_targets, targets], dim=1)
+
+        inputs_embeds = (
+            self.text_backbone.model.decoder.embed_tokens(
+                opt_tokens.input_ids))
+        inputs_embeds = torch.cat([inputs_opt, inputs_embeds], dim=1)
+
+        outputs = self.text_backbone(
+            inputs_embeds=inputs_embeds,
+            attention_mask=attention_mask,
+            return_dict=True,
+            labels=targets,
+        )
+        loss = outputs.loss
+
+        return {'loss': loss}
 
     def predict(self,
                 images: torch.Tensor,
@@ -146,7 +219,7 @@ class Blip2Caption(BaseModel):
             List[DataSample]: Return list of data samples.
         """
 
-        # extract image features from
+        # extract image features
         image_embeds = self.ln_vision_backbone(self.vision_backbone(images)[0])
         image_atts = torch.ones(
             image_embeds.size()[:-1],
@@ -169,15 +242,15 @@ class Blip2Caption(BaseModel):
 
         opt_tokens = self.tokenizer(
             prompt, return_tensors='pt').to(images.device)
-        input_ids = opt_tokens.input_ids
         attention_mask = torch.cat([attns_opt, opt_tokens.attention_mask],
                                    dim=1)
 
-        query_embeds = inputs_opt
+        inputs_embeds = (
+            self.text_backbone.get_input_embeddings()(opt_tokens.input_ids))
+        inputs_embeds = torch.cat([inputs_opt, inputs_embeds], dim=1)
 
         outputs = self.text_backbone.generate(
-            input_ids=input_ids,
-            query_embeds=query_embeds,
+            inputs_embeds=inputs_embeds,
             attention_mask=attention_mask,
             do_sample=False,
             top_p=0.9,

--- a/mmpretrain/models/multimodal/blip2/blip2_caption.py
+++ b/mmpretrain/models/multimodal/blip2/blip2_caption.py
@@ -275,7 +275,7 @@ class Blip2Caption(BaseModel):
         )
 
         output_text = self.tokenizer.batch_decode(
-            outputs[:, self.prompt_length:], skip_special_tokens=True)
+            outputs, skip_special_tokens=True)
         output_text = [text.strip() for text in output_text]
 
         out_data_samples = []

--- a/mmpretrain/models/multimodal/blip2/blip2_caption.py
+++ b/mmpretrain/models/multimodal/blip2/blip2_caption.py
@@ -165,14 +165,19 @@ class Blip2Caption(BaseModel):
         attns_opt = torch.ones(
             inputs_opt.size()[:-1], dtype=torch.long).to(images.device)
 
-        self.tokenizer.padding_side = 'right'
+        self.tokenizer.padding_side = "right"
 
         prompt = [
             data_sample.gt_caption + '\n' for data_sample in data_samples
         ]
 
         opt_tokens = self.tokenizer(
-            prompt, return_tensors='pt').to(images.device)
+            prompt,
+            return_tensors='pt',
+            padding="longest",
+            truncation=True,
+            max_length=self.max_txt_len,
+        ).to(images.device)
         attention_mask = torch.cat([attns_opt, opt_tokens.attention_mask],
                                    dim=1)
 
@@ -241,7 +246,12 @@ class Blip2Caption(BaseModel):
         prompt = [self.prompt] * image_embeds.size(0)
 
         opt_tokens = self.tokenizer(
-            prompt, return_tensors='pt').to(images.device)
+            prompt,
+            return_tensors='pt',
+            padding="longest",
+            truncation=True,
+            max_length=self.max_txt_len,
+        ).to(images.device)
         attention_mask = torch.cat([attns_opt, opt_tokens.attention_mask],
                                    dim=1)
 

--- a/mmpretrain/models/multimodal/blip2/blip2_caption.py
+++ b/mmpretrain/models/multimodal/blip2/blip2_caption.py
@@ -165,7 +165,7 @@ class Blip2Caption(BaseModel):
         attns_opt = torch.ones(
             inputs_opt.size()[:-1], dtype=torch.long).to(images.device)
 
-        self.tokenizer.padding_side = "right"
+        self.tokenizer.padding_side = 'right'
 
         prompt = [
             data_sample.gt_caption + '\n' for data_sample in data_samples

--- a/mmpretrain/models/multimodal/blip2/blip2_caption.py
+++ b/mmpretrain/models/multimodal/blip2/blip2_caption.py
@@ -165,7 +165,7 @@ class Blip2Caption(BaseModel):
         attns_opt = torch.ones(
             inputs_opt.size()[:-1], dtype=torch.long).to(images.device)
 
-        self.tokenizer.padding_side = "right"
+        self.tokenizer.padding_side = 'right'
 
         prompt = [
             data_sample.gt_caption + '\n' for data_sample in data_samples
@@ -174,7 +174,7 @@ class Blip2Caption(BaseModel):
         opt_tokens = self.tokenizer(
             prompt,
             return_tensors='pt',
-            padding="longest",
+            padding='longest',
             truncation=True,
             max_length=self.max_txt_len,
         ).to(images.device)
@@ -248,7 +248,7 @@ class Blip2Caption(BaseModel):
         opt_tokens = self.tokenizer(
             prompt,
             return_tensors='pt',
-            padding="longest",
+            padding='longest',
             truncation=True,
             max_length=self.max_txt_len,
         ).to(images.device)

--- a/mmpretrain/models/multimodal/blip2/blip2_caption.py
+++ b/mmpretrain/models/multimodal/blip2/blip2_caption.py
@@ -97,8 +97,7 @@ class Blip2Caption(BaseModel):
                 self._ignore_loading_llm_keys_hook)
 
         if hasattr(self, '_register_state_dict_hook'):
-            self._register_state_dict_hook(
-                self._igonre_saving_llm_keys_hook)
+            self._register_state_dict_hook(self._igonre_saving_llm_keys_hook)
 
     def forward(self,
                 images: torch.Tensor,
@@ -306,7 +305,7 @@ class Blip2Caption(BaseModel):
 
     @staticmethod
     def _igonre_saving_llm_keys_hook(module, state_dict, prefix, metadata):
-        """Avoid saving llm state dict"""
+        """Avoid saving llm state dict."""
         import re
         llm_pattern = '^text_backbone'
         keys = [k for k, _ in state_dict.items()]

--- a/mmpretrain/models/multimodal/blip2/blip2_caption.py
+++ b/mmpretrain/models/multimodal/blip2/blip2_caption.py
@@ -172,7 +172,8 @@ class Blip2Caption(BaseModel):
         self.tokenizer.padding_side = 'right'
 
         prompt = [
-            data_sample.gt_caption + '\n' for data_sample in data_samples
+            self.prompt + data_sample.gt_caption + '\n'
+            for data_sample in data_samples
         ]
 
         opt_tokens = self.tokenizer(
@@ -182,8 +183,6 @@ class Blip2Caption(BaseModel):
             truncation=True,
             max_length=self.max_txt_len,
         ).to(images.device)
-        attention_mask = torch.cat([attns_opt, opt_tokens.attention_mask],
-                                   dim=1)
 
         targets = opt_tokens.input_ids.masked_fill(
             opt_tokens.input_ids == self.tokenizer.pad_token_id, -100)
@@ -199,6 +198,8 @@ class Blip2Caption(BaseModel):
             self.text_backbone.model.decoder.embed_tokens(
                 opt_tokens.input_ids))
         inputs_embeds = torch.cat([inputs_opt, inputs_embeds], dim=1)
+        attention_mask = torch.cat([attns_opt, opt_tokens.attention_mask],
+                                   dim=1)
 
         outputs = self.text_backbone(
             inputs_embeds=inputs_embeds,


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

There is no `loss` function for `BLIP2`.

## Modification

1. Add the `loss`function of `BLIP2` based on https://github.com/salesforce/LAVIS/blob/main/lavis/models/blip2_models/blip2_opt.py
2. Fix `init_weights` bug of `Qformer`

## Experiment

Using LoRA, the training result on `COCOCaption` datatset is `BLEU@4`: 42.65, `CIDEr`: 143.84
The result reported in the original paper [BLIP-2: Bootstrapping Language-Image Pre-training with Frozen Image Encoders and Large Language Models](https://arxiv.org/pdf/2301.12597.pdf) is `BLEU@4`: 43.7, `CIDEr`: 145.8
However, I didn't finetune the whole vision backbone.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
