### PR TITLE
fix the issue#1698 about pre_norm of beit

### DIFF
--- a/mmpretrain/models/backbones/vision_transformer.py
+++ b/mmpretrain/models/backbones/vision_transformer.py
@@ -433,8 +433,9 @@ class VisionTransformer(BaseBackbone):
         for param in self.patch_embed.parameters():
             param.requires_grad = False
         # freeze pre-norm
-        for param in self.pre_norm.parameters():
-            param.requires_grad = False
+        if hasattr(self, 'pre_norm'):
+            for param in self.pre_norm.parameters():
+                param.requires_grad = False
         # freeze cls_token
         self.cls_token.requires_grad = False
         # freeze layers


### PR DESCRIPTION
Thanks for your contribution and we appreciate it a lot. The following instructions would make your pull request more healthy and more easily get feedback. If you do not understand some items, don't worry, just make the pull request and seek help from maintainers.

## Motivation

As the [Issue#1698](https://github.com/open-mmlab/mmpretrain/issues/1698) said. When freezing some layers of BEiT, it will raise an error due to the lack of `pre_norm`.

## Modification

In this PR, I want to fix [Issue#1698](https://github.com/open-mmlab/mmpretrain/issues/1698). So I modify the `_freeze_stages` method of `VisionTransformer` in `models/backbone/vision_transformer.py`, which is the base class of BEiT. After following modification, all model without `pre_norm` module can correctly freeze stages.

```
-        for param in self.pre_norm.parameters():
-            param.requires_grad = False
+        if hasattr(self, 'pre_norm'):
+            for param in self.pre_norm.parameters():
+                param.requires_grad = False
```

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ ] CLA has been signed and all committers have signed the CLA in this PR.
