### PR TITLE
Fix runtime requirements

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -2,6 +2,6 @@ einops
 importlib-metadata
 mat4py
 matplotlib
-modelindex
+model-index
 numpy
 rich


### PR DESCRIPTION
## Motivation

`modelindex` is the wrong package. Use `model-index` instead.

<img width="1098" alt="image" src="https://github.com/open-mmlab/mmpretrain/assets/29506042/6732d391-2835-4a19-89c1-34d017a41909">

## Modification

Change `modelindex` to `model-index`

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
