### PR TITLE
compatible with New Config in `mmpretrain.apis.get_model`

### DIFF
--- a/mmpretrain/apis/model.py
+++ b/mmpretrain/apis/model.py
@@ -1,7 +1,7 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import copy
-import inspect
 import fnmatch
+import inspect
 import os.path as osp
 import re
 import warnings

--- a/mmpretrain/apis/model.py
+++ b/mmpretrain/apis/model.py
@@ -1,5 +1,6 @@
 # Copyright (c) OpenMMLab. All rights reserved.
 import copy
+import inspect
 import fnmatch
 import os.path as osp
 import re
@@ -207,8 +208,12 @@ def get_model(model: Union[str, Config],
             dataset_meta = {'classes': checkpoint['meta']['CLASSES']}
 
     if len(dataset_meta) == 0 and 'test_dataloader' in config:
-        from mmpretrain.registry import DATASETS
-        dataset_class = DATASETS.get(config.test_dataloader.dataset.type)
+        # compatible with new config
+        if inspect.isclass(config.test_dataloader.dataset.type):
+            dataset_class = config.test_dataloader.dataset.type
+        else:
+            from mmpretrain.registry import DATASETS
+            dataset_class = DATASETS.get(config.test_dataloader.dataset.type)
         dataset_meta = getattr(dataset_class, 'METAINFO', {})
 
     if device_map is not None:


### PR DESCRIPTION

## Motivation

In the new config setting, the `type` value will change from `str` to `class`. Modify the `get_model` function to adopt `class` value.

## Modification

If the `type` value in the config is a class, use the class directly.

## BC-breaking (Optional)

Does the modification introduce changes that break the backward compatibility of the downstream repositories?
If so, please describe how it breaks the compatibility and how the downstream projects should modify their code to keep compatibility with this PR.

No.

## Use cases (Optional)

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

No.

## Checklist

**Before PR**:

- [x] Pre-commit or other linting tools are used to fix the potential lint issues.
- [x] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [x] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [x] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [x] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [x] CLA has been signed and all committers have signed the CLA in this PR.
