### PR TITLE
Update simmim_neck.py

### DIFF
--- a/mmpretrain/models/necks/simmim_neck.py
+++ b/mmpretrain/models/necks/simmim_neck.py
@@ -15,14 +15,15 @@ class SimMIMLinearDecoder(BaseModule):
     Args:
         in_channels (int): Channel dimension of the feature map.
         encoder_stride (int): The total stride of the encoder.
+        target_channels (int): Channel dimensions of original image.
     """
 
-    def __init__(self, in_channels: int, encoder_stride: int) -> None:
+    def __init__(self, in_channels: int, encoder_stride: int, target_channels: int = 3) -> None:
         super().__init__()
         self.decoder = nn.Sequential(
             nn.Conv2d(
                 in_channels=in_channels,
-                out_channels=encoder_stride**2 * 3,
+                out_channels=encoder_stride**2 * target_channels,
                 kernel_size=1),
             nn.PixelShuffle(encoder_stride),
         )


### PR DESCRIPTION


## Motivation

Enhancement to SimMIM module to enable usage in non-RGB cases.

## Modification

Update SimMIMLinearDecoder with `target_channels`. The downstream loss for SimMIM i.e. the `PixelReconstructionLoss` already allows user to set the number of channels through the `channel` argument.  Useful in cases when reconstructing non-rgb images.
 The value to `target_channels` is hardcoded to 3 to ensure all existing checkpoints work.


## Use cases (Optional)

SimMIM can now be trained for grayscale or hyperspectral images.

If this PR introduces a new feature, it is better to list some use cases here and update the documentation.

## Checklist

**Before PR**:

- [ ] Pre-commit or other linting tools are used to fix the potential lint issues.
- [ ] Bug fixes are fully covered by unit tests, the case that causes the bug should be added in the unit tests.
- [ ] The modification is covered by complete unit tests. If not, please add more unit test to ensure the correctness.
- [ ] The documentation has been modified accordingly, like docstring or example tutorials.

**After PR**:

- [ ] If the modification has potential influence on downstream or other related projects, this PR should be tested with those projects, like MMDet or MMSeg.
- [ x] CLA has been signed and all committers have signed the CLA in this PR.
